### PR TITLE
Add example showing use of await

### DIFF
--- a/examples/try_everything.py
+++ b/examples/try_everything.py
@@ -25,6 +25,12 @@ def test_params(request, name, id):
 def exception(request):
     raise ServerError("It's dead jim")
 
+@app.route("/await")
+async def test_await(request):
+    import asyncio
+    await asyncio.sleep(5)
+    return text("I'm feeling sleepy")
+
 
 # ----------------------------------------------- #
 # Exceptions


### PR DESCRIPTION
(First off, bravo on this great project!)

I wanted to do this for my own sanity checking, but might be useful for someone else to see so I'm submitting a PR.

Ran benchmark with `ab -kc 1000 -n 10000 http://127.0.0.1:8000/await`, demonstrating that concurrency remains extremely high while a request handler was awaiting.

Results with simulated 5 second delay, running 10 chunks of 1000 simultaneous requests:
```
Concurrency Level:      1000
Time taken for tests:   50.215 seconds
Complete requests:      10000
Failed requests:        0
Keep-Alive requests:    10000
Total transferred:      1470000 bytes
HTML transferred:       180000 bytes
Requests per second:    199.14 [#/sec] (mean)
Time per request:       5021.497 [ms] (mean)
Time per request:       5.021 [ms] (mean, across all concurrent requests)
Transfer rate:          28.59 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    3   8.0      0      36
Processing:  5000 5011   8.8   5009    5044
Waiting:     5000 5011   8.8   5009    5044
Total:       5000 5014  14.4   5009    5067

Percentage of the requests served within a certain time (ms)
  50%   5009
  66%   5011
  75%   5013
  80%   5018
  90%   5042
  95%   5053
  98%   5059
  99%   5063
 100%   5067 (longest request)
```