### PR TITLE
Fix Sanic arg in docs

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -7,7 +7,7 @@ Middleware is registered via the middleware decorator, and can either be added a
 ## Examples
 
 ```python
-app = Sanic('__name__')
+app = Sanic(__name__)
 
 @app.middleware
 async def halt_request(request):


### PR DESCRIPTION
I assume the value of `__name__` (module name) was intended.