### PR TITLE
refactored response object model

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ All tests were run on a AWS medium instance running ubuntu, using 1 process.  Ea
 
 ```python
 from sanic import Sanic
-from sanic.response import json
 
 app = Sanic(__name__)
 
 @app.route("/")
-async def test(request):
-    return json({ "hello": "world" })
+async def test(req, res):
+    res.add_headers({"hello":"world"})
+    return res.json({ "hello": "world" })
 
 app.run(host="0.0.0.0", port=8000)
+
 ```
 
 ## Installation
@@ -58,7 +59,7 @@ app.run(host="0.0.0.0", port=8000)
                      ▄▄▄▄▄
             ▀▀▀██████▄▄▄       _______________
           ▄▄▄▄▄  █████████▄  /                 \
-         ▀▀▀▀█████▌ ▀▐▄ ▀▐█ |   Gotta go fast!  | 
+         ▀▀▀▀█████▌ ▀▐▄ ▀▐█ |   Gotta go fast!  |
        ▀▀█████▄▄ ▀██████▄██ | _________________/
        ▀▄▄▄▄▄  ▀▀█▄▀█════█▀ |/
             ▀▀▀▄  ▀▀███ ▀       ▄▄

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -1,4 +1,4 @@
-from .response import text
+from .response import Response
 from traceback import format_exc
 
 
@@ -44,8 +44,8 @@ class Handler:
 
     def default(self, request, exception):
         if issubclass(type(exception), SanicException):
-            return text("Error: {}".format(exception), status=getattr(exception, 'status_code', 500))
+            return Response(status=getattr(exception, 'status_code', 500)).text("Error: {}".format(exception))
         elif self.sanic.debug:
-            return text("Error: {}\nException: {}".format(exception, format_exc()), status=500)
+            return Response(status=500).text("Error: {}\nException: {}".format(exception, format_exc()))
         else:
-            return text("An error occurred while generating the request", status=500)
+            return Response(status=500).text("An error occurred while generating the request")

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -18,7 +18,9 @@ STATUS_CODES = {
     504: 'Gateway Timeout',
 }
 
-
+"""
+Method for generating response from parameters/headers
+"""
 class HTTPResponse:
     __slots__ = ('body', 'status', 'content_type', 'headers')
 
@@ -54,15 +56,24 @@ class HTTPResponse:
                             self.body,
                         ])
 
+"""
+Class used by router to send a response object back to the route middleware
+"""
+class Response:
+    def __init__(self, status=200, headers={}):
+        self.status = status
+        self.headers = headers
 
-def json(body, status=200, headers=None):
-    return HTTPResponse(ujson.dumps(body), headers=headers, status=status,
-                        content_type="application/json; charset=utf-8")
+    def add_headers(self, headers):
+        for name, value in headers.items():
+            self.headers[name] = value
 
+    def json(self, body):
+        return HTTPResponse(ujson.dumps(body), headers=self.headers, status=self.status,
+          content_type="application/json; charset=utf-8")
 
-def text(body, status=200, headers=None):
-    return HTTPResponse(body, status=status, headers=headers, content_type="text/plain; charset=utf-8")
+    def text(self, body):
+        return HTTPResponse(body, status=self.status, headers=self.headers, content_type="text/plain; charset=utf-8")
 
-
-def html(body, status=200, headers=None):
-    return HTTPResponse(body, status=status, headers=headers, content_type="text/html; charset=utf-8")
+    def html(self, body):
+        return HTTPResponse(body, status=self.status, headers=self.headers, content_type="text/html; charset=utf-8")

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -7,7 +7,7 @@ from .config import Config
 from .exceptions import Handler
 from .log import log, logging
 from .middleware import Middleware
-from .response import HTTPResponse
+from .response import HTTPResponse, Response
 from .router import Router
 from .server import serve
 from .exceptions import ServerError
@@ -118,7 +118,7 @@ class Sanic:
                     raise ServerError("'None' was returned while requesting a handler from the router")
 
                 # Run response handler
-                response = handler(request, *args, **kwargs)
+                response = handler(request, Response(), *args, **kwargs)
                 if isawaitable(response):
                     response = await response
 


### PR DESCRIPTION
I want to change how the Response model works by creating an object that allows intermediary header changing, and overall response changing. 

For the future of this framework, the response should be modified so that more complicated responses like cookies can be used.

i.e
```python
class Response:
    pass
    
    def set_cookie(self, name, value):
         self.add_headers("Cookie":"{}={}".format(name,value))
```
which will be used like this

```python
@app.route("/")
def handler(req, res):
    res.set_cookie("hello", "world")
    return res.json({"hello":"world")
```
where res is instantiated into the handler by the main sanic.py.

This type of structure will allow better response formulation rather than using the bare response types and pushing in the headers manually. We can write stuff like cookies that will be reused.

My next PR will be implementing cookies. 

This is experimental, I just want to know what you think