### PR TITLE
Add .travis.yml with flake8 checks and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - "3.5"
 # command to install dependencies
 install:
-  - "pip install requirements.txt"
-  - "pip install requirements-dev.txt"
+  - "pip install -r requirements.txt"
+  - "pip install -r requirements-dev.txt"
   - "python setup.py install"
   - "pip install flake8"
   - "pip install pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "3.5"
+# command to install dependencies
+install:
+  - "pip install requirements.txt"
+  - "pip install requirements-dev.txt"
+  - "python setup.py install"
+  - "pip install flake8"
+  - "pip install pytest"
+# flake8 check
+before_script: "flake8 sanic"
+# command to run tests
+script: "py.test -v tests"


### PR DESCRIPTION
This adds a `.travis.yml` with the ability to:

- Do `flake8` checks for PEP8 compliance
- Run the tests

Let me know if you don't want the PEP8 checks.

Checks for this PR will fail initially until the PEP8 errors (can be fixed with a tool like `autopep8`) are fulfilled but I do think it is important to have PEP8 checks to keep the quality of the code up while maintaining a coding standard.

They can be removed but I do think they are important.

Auto-uploading to PyPI can be done but it will need to be done by @channelcat, instructions for that can be found here, https://docs.travis-ci.com/user/deployment/pypi/

Solves for issue #3 