### PR TITLE
Adds smart handling of response objects

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from .log import log
 from .request import Request
+from .response import HTTPResponse, json, text
 
 
 class Signal:
@@ -124,6 +125,10 @@ class HttpProtocol(asyncio.Protocol):
         try:
             keep_alive = all(
                 [self.parser.should_keep_alive(), self.signal.stopped])
+            if isinstance(response, dict):
+                response = json(response)
+            elif not isinstance(response, HTTPResponse):
+                response = text(response)
             self.transport.write(
                 response.output(
                     self.request.version, keep_alive, self.request_timeout))

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -131,10 +131,11 @@ class HttpProtocol(asyncio.Protocol):
         try:
             keep_alive = all(
                 [self.parser.should_keep_alive(), self.signal.stopped])
-            # Handling for returning dicts and everything not an HTTPResponse
-            if isinstance(response, dict):
+            if isinstance(response, HTTPResponse):  # Easy pass first
+                pass
+            elif isinstance(response, (dict, list)):
                 response = json(response)
-            elif not isinstance(response, HTTPResponse):
+            else:
                 response = text(str(response))
             self.transport.write(
                 response.output(

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -124,8 +124,8 @@ class HttpProtocol(asyncio.Protocol):
     def write_response(self, response):
         """Attempts to write the response to the transport
 
-        This will attempt to intelligently handle any type of python object 
-        with dicts being treated like json and everything else being casted 
+        This will attempt to intelligently handle any type of python object
+        with dicts being treated like json and everything else being casted
         to str if it is not an HTTPResponse object
         """
         try:

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -122,13 +122,20 @@ class HttpProtocol(asyncio.Protocol):
     # -------------------------------------------- #
 
     def write_response(self, response):
+        """Attempts to write the resposne to the transport
+
+        This will attempt to smartly handle any type of python object with
+        dicts being treated like json and everything else being casted to str
+        if it is not an HTTPResponse object
+        """
         try:
             keep_alive = all(
                 [self.parser.should_keep_alive(), self.signal.stopped])
+            # Handling for returning dicts and everything not an HTTPResponse
             if isinstance(response, dict):
                 response = json(response)
             elif not isinstance(response, HTTPResponse):
-                response = text(response)
+                response = text(str(response))
             self.transport.write(
                 response.output(
                     self.request.version, keep_alive, self.request_timeout))

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -122,7 +122,7 @@ class HttpProtocol(asyncio.Protocol):
     # -------------------------------------------- #
 
     def write_response(self, response):
-        """Attempts to write the resposne to the transport
+        """Attempts to write the response to the transport
 
         This will attempt to smartly handle any type of python object with
         dicts being treated like json and everything else being casted to str

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -124,9 +124,9 @@ class HttpProtocol(asyncio.Protocol):
     def write_response(self, response):
         """Attempts to write the response to the transport
 
-        This will attempt to smartly handle any type of python object with
-        dicts being treated like json and everything else being casted to str
-        if it is not an HTTPResponse object
+        This will attempt to intelligently handle any type of python object 
+        with dicts being treated like json and everything else being casted 
+        to str if it is not an HTTPResponse object
         """
         try:
             keep_alive = all(

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,51 @@
+from json import loads as json_loads, JSONDecodeError
+from random import choice
+
+from sanic import Sanic
+from sanic.utils import sanic_endpoint_test
+
+
+def test_json():
+    """Tests the smart handling of dicts for handlers"""
+    app = Sanic('test_json')
+
+    @app.route('/')
+    async def handler(request):
+        return {"test": True}
+
+    request, response = sanic_endpoint_test(app)
+
+    try:
+        results = json_loads(response.text)
+    except JSONDecodeError:
+        raise ValueError(
+            "Expected JSON response but got '{}'".format(response))
+
+    assert results.get('test') is True
+
+
+def test_text():
+    """Tests the smart handling of strings for handlers"""
+    app = Sanic('test_text')
+
+    @app.route('/')
+    async def handler(request):
+        return 'Hello'
+
+    request, response = sanic_endpoint_test(app)
+
+    assert response.text == 'Hello'
+
+
+def test_int():
+    """Tests the smart handling of ints for handlers"""
+    app = Sanic('test_int')
+    random_int = choice(range(0, 10000))
+
+    @app.route('/')
+    async def handler(request):
+        return random_int
+
+    request, response = sanic_endpoint_test(app)
+
+    assert response.text == str(random_int)


### PR DESCRIPTION
Returning dicts in handlers will now convert them to json and returning anything other than an HTTPResponse will return its `str` representation. 

In response to #50 

# Old
```python
from sanic import Sanic
from sanic.response import json
app = Sanic('test_json')

@app.route('/')
async def handler(request):
    return json({"test": True})
```

# New
```python
from sanic import Sanic
app = Sanic('test_json')

@app.route('/')
async def handler(request):
    return {"test": True}
```
