### PR TITLE
Removes module-level logging override

### DIFF
--- a/examples/try_everything.py
+++ b/examples/try_everything.py
@@ -1,5 +1,5 @@
+import logging
 from sanic import Sanic
-from sanic.log import log
 from sanic.response import json, text
 from sanic.exceptions import ServerError
 
@@ -65,11 +65,11 @@ def query_string(request):
 # ----------------------------------------------- #
 
 def after_start(loop):
-    log.info("OH OH OH OH OHHHHHHHH")
+    logging.info("OH OH OH OH OHHHHHHHH")
 
 
 def before_stop(loop):
-    log.info("TRIED EVERYTHING")
+    logging.info("TRIED EVERYTHING")
 
 
 app.run(host="0.0.0.0", port=8000, debug=True, after_start=after_start, before_stop=before_stop)

--- a/sanic/log.py
+++ b/sanic/log.py
@@ -1,5 +1,0 @@
-import logging
-
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s: %(levelname)s: %(message)s")
-log = logging.getLogger(__name__)

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -1,10 +1,9 @@
+import logging
 from cgi import parse_header
 from collections import namedtuple
 from httptools import parse_url
 from urllib.parse import parse_qs
 from ujson import loads as json_loads
-
-from .log import log
 
 
 class RequestParameters(dict):
@@ -82,7 +81,7 @@ class Request:
                     self.parsed_form, self.parsed_files = (
                         parse_multipart_form(self.body, boundary))
             except Exception as e:
-                log.exception(e)
+                logging.exception(e)
                 pass
 
         return self.parsed_form

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -81,7 +81,7 @@ class Request:
                     self.parsed_form, self.parsed_files = (
                         parse_multipart_form(self.body, boundary))
             except Exception as e:
-                logging.exception(e)
+                logging.exception("An error occurred while parsing the request's form body")
                 pass
 
         return self.parsed_form

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -1,10 +1,10 @@
+import logging
 import asyncio
 from inspect import isawaitable
 from traceback import format_exc
 
 from .config import Config
 from .exceptions import Handler
-from .log import log, logging
 from .response import HTTPResponse
 from .router import Router
 from .server import serve
@@ -184,11 +184,11 @@ class Sanic:
         self.debug = debug
 
         if debug:
-            log.setLevel(logging.DEBUG)
-        log.debug(self.config.LOGO)
+            logging.setLevel(logging.DEBUG)
+        logging.debug(self.config.LOGO)
 
         # Serve
-        log.info('Goin\' Fast @ http://{}:{}'.format(host, port))
+        logging.info('Goin\' Fast @ http://{}:{}'.format(host, port))
 
         try:
             serve(
@@ -202,7 +202,7 @@ class Sanic:
                 request_max_size=self.config.REQUEST_MAX_SIZE,
             )
         except Exception as e:
-            log.exception(
+            logging.exception(
                 'Experienced exception while trying to serve: {}'.format(e))
             pass
 

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from inspect import isawaitable
 from signal import SIGINT, SIGTERM
 
@@ -9,7 +10,6 @@ try:
 except ImportError:
     async_loop = asyncio
 
-from .log import log
 from .request import Request
 
 
@@ -136,7 +136,7 @@ class HttpProtocol(asyncio.Protocol):
                 "Writing request failed, connection closed {}".format(e))
 
     def bail_out(self, message):
-        log.error(message)
+        logging.error(message)
         self.transport.close()
 
     def cleanup(self):
@@ -180,7 +180,7 @@ def serve(host, port, request_handler, after_start=None, before_stop=None,
     try:
         http_server = loop.run_until_complete(server_coroutine)
     except Exception as e:
-        log.error("Unable to start server: {}".format(e))
+        logging.error("Unable to start server: {}".format(e))
         return
 
     # Run the on_start function if provided
@@ -196,7 +196,7 @@ def serve(host, port, request_handler, after_start=None, before_stop=None,
     try:
         loop.run_forever()
     finally:
-        log.info("Stop requested, draining connections...")
+        logging.info("Stop requested, draining connections...")
 
         # Run the on_stop function if provided
         if before_stop:
@@ -217,4 +217,4 @@ def serve(host, port, request_handler, after_start=None, before_stop=None,
             loop.run_until_complete(asyncio.sleep(0.1))
 
         loop.close()
-        log.info("Server Stopped")
+        logging.info("Server Stopped")

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -1,5 +1,5 @@
+import logging
 import aiohttp
-from sanic.log import log
 
 HOST = '127.0.0.1'
 PORT = 42101
@@ -7,7 +7,7 @@ PORT = 42101
 
 async def local_request(method, uri, *args, **kwargs):
     url = 'http://{host}:{port}{uri}'.format(host=HOST, port=PORT, uri=uri)
-    log.info(url)
+    logging.info(url)
     async with aiohttp.ClientSession() as session:
         async with getattr(session, method)(url, *args, **kwargs) as response:
             response.text = await response.text()


### PR DESCRIPTION
In general, I think it is bad practice for a module to override a user's logging.basicConfig(). It's not common to see libraries wrapping the python `logging` module. Use the builtin module and allow the user to define their own `format`, `level`, etc.