### PR TITLE
Adds `tornado` test server for speed comparison (#13)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ gunicorn
 bottle
 kyoukai
 falcon
+tornado

--- a/tests/performance/tornado/simple_server.py
+++ b/tests/performance/tornado/simple_server.py
@@ -1,0 +1,19 @@
+# Run with: python simple_server.py
+import ujson
+from tornado import ioloop, web
+
+
+class MainHandler(web.RequestHandler):
+    def get(self):
+        self.write(ujson.dumps({'test': True}))
+
+
+app = web.Application([
+    (r'/', MainHandler)
+],  debug=False,
+    compress_response=False,
+    static_hash_cache=True
+)
+
+app.listen(8000)
+ioloop.IOLoop.current().start()


### PR DESCRIPTION
Tentative benchmarks, not performed on AWS with command `wrk -t1 -c100 -d10s http://localhost:8000/`

**Python 2**
```
Running 10s test @ http://localhost:8000/
  1 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    28.58ms    2.09ms  43.29ms   73.31%
    Req/Sec     3.51k   218.88     3.86k    67.00%
  34937 requests in 10.00s, 6.86MB read
Requests/sec:   3493.38
Transfer/sec:    702.77KB
```

**Python 3**
```
Running 10s test @ http://localhost:8000/
  1 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    31.07ms    2.16ms 100.12ms   87.83%
    Req/Sec     3.23k   176.66     3.51k    63.00%
  32133 requests in 10.00s, 6.37MB read
Requests/sec:   3212.84
Transfer/sec:    652.61KB
```