### PR TITLE
Faster router

### DIFF
--- a/sanic/config.py
+++ b/sanic/config.py
@@ -22,3 +22,4 @@ class Config:
 """
     REQUEST_MAX_SIZE = 100000000  # 100 megababies
     REQUEST_TIMEOUT = 60  # 60 seconds
+    ROUTER_CACHE_SIZE = 1024

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -61,16 +61,16 @@ class Router:
 
         def add_parameter(match):
             # We could receive NAME or NAME:PATTERN
-            parameter_name = match.group(1)
-            parameter_pattern = 'string'
-            if ':' in parameter_name:
-                parameter_name, parameter_pattern = parameter_name.split(':', 1)
+            name = match.group(1)
+            pattern = 'string'
+            if ':' in name:
+                name, pattern = name.split(':', 1)
 
-            default = (str, parameter_pattern)
+            default = (str, pattern)
             # Pull from pre-configured types
-            parameter_type, parameter_pattern = REGEX_TYPES.get(parameter_pattern, default)
-            parameters.append(Parameter(name=parameter_name, cast=parameter_type))
-            return '({})'.format(parameter_pattern)
+            _type, pattern = REGEX_TYPES.get(pattern, default)
+            parameters.append(Parameter(name=name, cast=_type))
+            return '({})'.format(pattern)
 
         pattern_string = re.sub(r'<(.+?)>', add_parameter, uri)
         pattern = re.compile(r'^{}$'.format(pattern_string))
@@ -109,5 +109,7 @@ class Router:
                 'Method {} not allowed for URL {}'.format(
                     request.method, url), status_code=405)
 
-        kwargs = {p.name: p.cast(value) for value, p in zip(match.groups(1), route.parameters)}
+        kwargs = {p.name: p.cast(value)
+                  for value, p
+                  in zip(match.groups(1), route.parameters)}
         return route.handler, [], kwargs

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -5,6 +5,13 @@ from .exceptions import NotFound, InvalidUsage
 Route = namedtuple("Route", ['handler', 'methods', 'pattern', 'parameters'])
 Parameter = namedtuple("Parameter", ['name', 'cast'])
 
+REGEX_TYPES = {
+    "string": (None, "[^/]+"),
+    "int": (int, "\d+"),
+    "number": (float, "[0-9\\.]+"),
+    "alpha": (None, "[A-Za-z]+"),
+}
+
 
 class Router:
     """
@@ -25,12 +32,6 @@ class Router:
         I should feel bad
     """
     routes = None
-    regex_types = {
-        "string": (None, "[^/]+"),
-        "int": (int, "\d+"),
-        "number": (float, "[0-9\\.]+"),
-        "alpha": (None, "[A-Za-z]+"),
-    }
 
     def __init__(self):
         self.routes = []
@@ -63,7 +64,7 @@ class Router:
                 parameter_pattern = 'string'
 
             # Pull from pre-configured types
-            parameter_regex = self.regex_types.get(parameter_pattern)
+            parameter_regex = REGEX_TYPES.get(parameter_pattern)
             if parameter_regex:
                 parameter_type, parameter_pattern = parameter_regex
             else:

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -2,14 +2,14 @@ import re
 from collections import namedtuple
 from .exceptions import NotFound, InvalidUsage
 
-Route = namedtuple("Route", ['handler', 'methods', 'pattern', 'parameters'])
-Parameter = namedtuple("Parameter", ['name', 'cast'])
+Route = namedtuple('Route', ['handler', 'methods', 'pattern', 'parameters'])
+Parameter = namedtuple('Parameter', ['name', 'cast'])
 
 REGEX_TYPES = {
-    "string": (None, "[^/]+"),
-    "int": (int, "\d+"),
-    "number": (float, "[0-9\\.]+"),
-    "alpha": (None, "[A-Za-z]+"),
+    'string': (None, r'[^/]+'),
+    'int': (int, r'\d+'),
+    'number': (float, r'[0-9\\.]+'),
+    'alpha': (None, r'[A-Za-z]+'),
 }
 
 
@@ -67,8 +67,8 @@ class Router:
             parameters.append(Parameter(name=parameter_name, cast=parameter_type))
             return '({})'.format(parameter_pattern)
 
-        pattern_string = re.sub("<(.+?)>", add_parameter, uri)
-        pattern = re.compile("^{}$".format(pattern_string))
+        pattern_string = re.sub(r'<(.+?)>', add_parameter, uri)
+        pattern = re.compile(r'^{}$'.format(pattern_string))
 
         route = Route(
             handler=handler, methods=methods_dict, pattern=pattern,
@@ -101,8 +101,8 @@ class Router:
         if route:
             if route.methods and request.method not in route.methods:
                 raise InvalidUsage(
-                    "Method {} not allowed for URL {}".format(
+                    'Method {} not allowed for URL {}'.format(
                         request.method, request.url), status_code=405)
             return route.handler, args, kwargs
         else:
-            raise NotFound("Requested URL {} not found".format(request.url))
+            raise NotFound('Requested URL {} not found'.format(request.url))

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -56,24 +56,16 @@ class Router:
 
         def add_parameter(match):
             # We could receive NAME or NAME:PATTERN
-            parts = match.group(1).split(':')
-            if len(parts) == 2:
-                parameter_name, parameter_pattern = parts
-            else:
-                parameter_name = parts[0]
-                parameter_pattern = 'string'
+            parameter_name = match.group(1)
+            parameter_pattern = 'string'
+            if ':' in parameter_name:
+                parameter_name, parameter_pattern = parameter_name.split(':', 1)
 
+            default = (None, parameter_pattern)
             # Pull from pre-configured types
-            parameter_regex = REGEX_TYPES.get(parameter_pattern)
-            if parameter_regex:
-                parameter_type, parameter_pattern = parameter_regex
-            else:
-                parameter_type = None
-
-            parameter = Parameter(name=parameter_name, cast=parameter_type)
-            parameters.append(parameter)
-
-            return "({})".format(parameter_pattern)
+            parameter_type, parameter_pattern = REGEX_TYPES.get(parameter_pattern, default)
+            parameters.append(Parameter(name=parameter_name, cast=parameter_type))
+            return '({})'.format(parameter_pattern)
 
         pattern_string = re.sub("<(.+?)>", add_parameter, uri)
         pattern = re.compile("^{}$".format(pattern_string))

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -113,34 +113,3 @@ class Router:
             return route.handler, args, kwargs
         else:
             raise NotFound("Requested URL {} not found".format(request.url))
-
-
-class SimpleRouter:
-    """
-    Simple router records and reads all routes from a dictionary
-    It does not support parameters in routes, but is very fast
-    """
-    routes = None
-
-    def __init__(self):
-        self.routes = {}
-
-    def add(self, uri, methods, handler):
-        # Dict for faster lookups of method allowed
-        methods_dict = None
-        if methods:
-            methods_dict = {method: True for method in methods}
-        self.routes[uri] = Route(
-            handler=handler, methods=methods_dict, pattern=uri,
-            parameters=None)
-
-    def get(self, request):
-        route = self.routes.get(request.url)
-        if route:
-            if route.methods and request.method not in route.methods:
-                raise InvalidUsage(
-                    "Method {} not allowed for URL {}".format(
-                        request.method, request.url), status_code=405)
-            return route.handler, [], {}
-        else:
-            raise NotFound("Requested URL {} not found".format(request.url))

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -50,9 +50,8 @@ class Router:
         """
 
         # Dict for faster lookups of if method allowed
-        methods_dict = None
         if methods:
-            methods_dict = {method: True for method in methods}
+            methods = frozenset(methods)
 
         parameters = []
 
@@ -73,7 +72,7 @@ class Router:
         pattern = re.compile(r'^{}$'.format(pattern_string))
 
         route = Route(
-            handler=handler, methods=methods_dict, pattern=pattern,
+            handler=handler, methods=methods, pattern=pattern,
             parameters=parameters)
         self.routes.append(route)
 

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -1,5 +1,7 @@
 import re
 from collections import namedtuple
+from functools import lru_cache
+from .config import Config
 from .exceptions import NotFound, InvalidUsage
 
 Route = namedtuple('Route', ['handler', 'methods', 'pattern', 'parameters'])
@@ -75,6 +77,7 @@ class Router:
             parameters=parameters)
         self.routes.append(route)
 
+    @lru_cache(maxsize=Config.ROUTER_CACHE_SIZE)
     def get(self, request):
         """
         Gets a request handler based on the URL of the request, or raises an


### PR DESCRIPTION
I've done a few different things here.

1. Removed the simple router since I think the regular route with a large enough cache should be very close in terms of speed
2.  Refactor the existing code
3. Added a lru_cache to the get request
4. Made a really simple hash lookup so it doesn't need to loop over all routes

If this lands because of 4. regexes with / in them won't work which is a bit of a trade off. Right now though regexes with : in them will have issues because of the split so I'm not sure it's worse? Might be worse thinking about limiting even further like flask does since that will improve lookup performance.