### PR TITLE
Blueprint start/stop listeners + ordering

### DIFF
--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -84,7 +84,6 @@ def ignore_404s(request, exception):
 ## Start and Stop
 Blueprints and run functions during the start and stop process of the server.
 If running in multiprocessor mode (more than 1 worker), these are triggered
-after forking
 Available events are:
 
  * before_server_start - Executed before the server begins to accept connections

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -80,3 +80,26 @@ Exceptions can also be applied exclusively to blueprints globally.
 def ignore_404s(request, exception):
 	return text("Yep, I totally found the page: {}".format(request.url))
 ```
+
+## Start and Stop
+Blueprints and run functions during the start and stop process of the server.
+If running in multiprocessor mode (more than 1 worker), these are triggered
+Available events are:
+
+ * before_server_start - Executed before the server begins to accept connections
+ * after_server_start - Executed after the server begins to accept connections
+ * before_server_stop - Executed before the server stops accepting connections
+ * after_server_stop - Executed after the server is stopped and all requests are complete
+
+```python
+bp = Blueprint('my_blueprint')
+
+@bp.listen('before_server_start')
+async def setup_connection():
+    global database
+    database = mysql.connect(host='127.0.0.1'...)
+    
+@bp.listen('after_server_stop')
+async def close_connection():
+    await database.close()
+```

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -83,7 +83,7 @@ def ignore_404s(request, exception):
 
 ## Start and Stop
 Blueprints and run functions during the start and stop process of the server.
-If running in multiprocessor mode (more than 1 worker), these are triggered
+If running in multiprocessor mode (more than 1 worker), these are triggered after the workers fork
 Available events are:
 
  * before_server_start - Executed before the server begins to accept connections

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -84,6 +84,7 @@ def ignore_404s(request, exception):
 ## Start and Stop
 Blueprints and run functions during the start and stop process of the server.
 If running in multiprocessor mode (more than 1 worker), these are triggered
+after forking
 Available events are:
 
  * before_server_start - Executed before the server begins to accept connections

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+
+
 class BlueprintSetup:
     """
     """
@@ -22,7 +25,7 @@ class BlueprintSetup:
         if self.url_prefix:
             uri = self.url_prefix + uri
 
-        self.app.router.add(uri, methods, handler)
+        self.app.route(uri=uri, methods=methods)(handler)
 
     def add_exception(self, handler, *args, **kwargs):
         """
@@ -42,9 +45,15 @@ class BlueprintSetup:
 
 class Blueprint:
     def __init__(self, name, url_prefix=None):
+        """
+        Creates a new blueprint
+        :param name: Unique name of the blueprint
+        :param url_prefix: URL to be prefixed before all route URLs
+        """
         self.name = name
         self.url_prefix = url_prefix
         self.deferred_functions = []
+        self.listeners = defaultdict(list)
 
     def record(self, func):
         """
@@ -71,6 +80,14 @@ class Blueprint:
         def decorator(handler):
             self.record(lambda s: s.add_route(handler, uri, methods))
             return handler
+        return decorator
+
+    def listener(self, event):
+        """
+        """
+        def decorator(listener):
+            self.listeners[event].append(listener)
+            return listener
         return decorator
 
     def middleware(self, *args, **kwargs):

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -163,7 +163,7 @@ def trigger_events(events, loop):
     :param loop: event loop
     """
     if events:
-        if type(events) is not list:
+        if not isinstance(events, list):
             events = [events]
         for event in events:
             result = event(loop)

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -24,7 +24,7 @@ def sanic_endpoint_test(app, method='get', uri='/', gather_request=True,
         def _collect_request(request):
             results.append(request)
 
-    async def _collect_response(loop):
+    async def _collect_response(sanic, loop):
         try:
             response = await local_request(method, uri, *request_args,
                                            **request_kwargs)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -109,3 +109,39 @@ def test_bp_exception_handler():
 
     request, response = sanic_endpoint_test(app, uri='/3')
     assert response.status == 200
+
+def test_bp_listeners():
+    app = Sanic('test_middleware')
+    blueprint = Blueprint('test_middleware')
+
+    order = []
+
+    @blueprint.listener('before_server_start')
+    def handler_1(sanic, loop):
+        order.append(1)
+
+    @blueprint.listener('after_server_start')
+    def handler_2(sanic, loop):
+        order.append(2)
+
+    @blueprint.listener('after_server_start')
+    def handler_3(sanic, loop):
+        order.append(3)
+
+    @blueprint.listener('before_server_stop')
+    def handler_4(sanic, loop):
+        order.append(5)
+
+    @blueprint.listener('before_server_stop')
+    def handler_5(sanic, loop):
+        order.append(4)
+
+    @blueprint.listener('after_server_stop')
+    def handler_6(sanic, loop):
+        order.append(6)
+
+    app.register_blueprint(blueprint)
+
+    request, response = sanic_endpoint_test(app, uri='/')
+
+    assert order == [1,2,3,4,5,6]


### PR DESCRIPTION
Added blueprint start/stop listeners
Added sanic as the first argument in listeners triggered when the server starts/stops
reversed the order of response middleware