### PR TITLE
Add transport to Request

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -31,12 +31,12 @@ class Request:
     Properties of an HTTP request such as URL, headers, etc.
     """
     __slots__ = (
-        'url', 'headers', 'version', 'method', '_cookies',
+        'url', 'headers', 'version', 'method', 'transport', '_cookies',
         'query_string', 'body',
         'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
     )
 
-    def __init__(self, url_bytes, headers, version, method):
+    def __init__(self, url_bytes, headers, version, method, transport):
         # TODO: Content-Encoding detection
         url_parsed = parse_url(url_bytes)
         self.url = url_parsed.path.decode('utf-8')
@@ -46,6 +46,7 @@ class Request:
         self.query_string = None
         if url_parsed.query:
             self.query_string = url_parsed.query.decode('utf-8')
+        self.transport = transport
 
         # Init but do not inhale
         self.body = None

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -106,7 +106,8 @@ class HttpProtocol(asyncio.Protocol):
             url_bytes=self.url,
             headers=dict(self.headers),
             version=self.parser.get_http_version(),
-            method=self.parser.get_method().decode()
+            method=self.parser.get_method().decode(),
+            transport=self.transport
         )
 
     def on_body(self, body):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -115,3 +115,22 @@ def test_post_form_multipart_form_data():
     request, response = sanic_endpoint_test(app, data=payload, headers=headers)
 
     assert request.form.get('test') == 'OK'
+
+
+# ------------------------------------------------------------ #
+#  Transport
+# ------------------------------------------------------------ #
+
+def test_transport():
+    import re
+
+    app = Sanic('test_transport')
+
+    @app.route('/')
+    def handler(request):
+        peername = request.transport.get_extra_info('peername')
+        return text(str(peername))
+
+    request, response = sanic_endpoint_test(app)
+
+    assert re.match(r"^\('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', \d+\)$", response.text)


### PR DESCRIPTION
Add transport to the request object (like aiohttp) so that extra information such as peername can be queried as well as to provide the foundation for upgrading the connection to a websocket if someone wanted to that with the help of an external websocket library. While I included a simple test, this is more of a proposal since I am new to the code base and do not understand all the potential ramifications.
