### PR TITLE
Keep alive timeout fix

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -18,6 +18,10 @@ from .request import Request
 class Signal:
     stopped = False
 
+
+current_time = None
+
+
 class HttpProtocol(asyncio.Protocol):
     __slots__ = (
         # event loop, connection
@@ -171,8 +175,7 @@ class HttpProtocol(asyncio.Protocol):
             return True
         return False
 
-# Keep check on the current time
-current_time = None
+
 def update_current_time(loop):
     """
     Caches the current time, since it is needed
@@ -197,6 +200,7 @@ def trigger_events(events, loop):
             result = event(loop)
             if isawaitable(result):
                 loop.run_until_complete(result)
+
 
 def serve(host, port, request_handler, before_start=None, after_start=None,
           before_stop=None, after_stop=None,

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -2,6 +2,7 @@ import asyncio
 from functools import partial
 from inspect import isawaitable
 from signal import SIGINT, SIGTERM
+from time import time
 
 import httptools
 
@@ -180,8 +181,8 @@ def update_current_time(loop):
     :return:
     """
     global current_time
-    current_time = loop.time()
-    loop.call_later(0.5, partial(update_current_time, loop))
+    current_time = time()
+    loop.call_later(1, partial(update_current_time, loop))
 
 
 def trigger_events(events, loop):


### PR DESCRIPTION
Currently requests time out and forcibly close 60 seconds (configurable) after the connection opens.  This can cause healthy keep-alive requests to spontaneously die mid-request.  I've added in logic to update the request timeout after each response.  With caching the system time every second, the impact seems to be a slowdown of ~300-500 requests/sec.

I looked into setting socket options but I can't seem to find a keep-alive timeout.

Since this isn't a critical fix, I'm leaving this open for a bit in case anyone else has a clever or less impactful solution.
