### PR TITLE
fix(blueprints): @middleware IndexError

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -109,8 +109,9 @@ class Blueprint:
 
         # Detect which way this was called, @middleware or @middleware('AT')
         if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
+            middleware = args[0]
             args = []
-            return register_middleware(args[0])
+            return register_middleware(middleware)
         else:
             return register_middleware
 


### PR DESCRIPTION
I think it`s just a mistake here (https://github.com/channelcat/sanic/blob/74ae0007d3a7bfea562e8b4a29880184815f9155/sanic/blueprints.py#L112-L113)

```
            args = []
            return register_middleware(args[0])
```

We just set args to empty list and then call the `args[0]`

My code:

```
bp = Blueprint('sessions', '/sessions')

@bp.middleware
async def session_middleware(request):
    ...

```

Produce the error:

```
Traceback (most recent call last):
  File "main.py", line 7, in <module>
    from sessions.blueprint import bp
  File "/Users/pahaz/cross-social-science/sessions/blueprint.py", line 25, in <module>
    @bp.middleware
  File "/Users/pahaz/.virtualenvs/cross-social-science/lib/python3.5/site-packages/sanic/blueprints.py", line 113, in middleware
    return register_middleware(args[0])
IndexError: list index out of range
```