### PR TITLE
Fix value error for query string test

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -56,7 +56,7 @@ def test_query_string():
     async def handler(request):
         return text('OK')
 
-    request, response = sanic_endpoint_test(app, params=[("test1", 1), ("test2", "false"), ("test2", "true")])
+    request, response = sanic_endpoint_test(app, params=[("test1", "1"), ("test2", "false"), ("test2", "true")])
 
     assert request.args.get('test1') == '1'
     assert request.args.get('test2') == 'false'


### PR DESCRIPTION
Fixes the test failures found in #140 and #139 

Caused by:

File "yarl/_quoting.pyx", line 46, in yarl._quoting._quote (yarl/_quoting.c:1384) TypeError: Argument should be str

https://github.com/aio-libs/yarl/blob/master/yarl/_quoting.pyx#L45

