### PR TITLE
fix(request.py): problem in case of request without content-type header

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -70,22 +70,23 @@ class Request:
         if self.parsed_form is None:
             self.parsed_form = {}
             self.parsed_files = {}
-            content_type, parameters = parse_header(
-                self.headers.get('Content-Type', ''))
-            try:
-                is_url_encoded = (
-                    content_type == 'application/x-www-form-urlencoded')
-                if content_type is None or is_url_encoded:
-                    self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode('utf-8')))
-                elif content_type == 'multipart/form-data':
-                    # TODO: Stream this instead of reading to/from memory
-                    boundary = parameters['boundary'].encode('utf-8')
-                    self.parsed_form, self.parsed_files = (
-                        parse_multipart_form(self.body, boundary))
-            except Exception as e:
-                log.exception(e)
-                pass
+            content_type = self.headers.get('Content-Type')
+            if content_type:
+                content_type, parameters = parse_header(content_type)
+                try:
+                    is_url_encoded = (
+                        content_type == 'application/x-www-form-urlencoded')
+                    if content_type is None or is_url_encoded:
+                        self.parsed_form = RequestParameters(
+                            parse_qs(self.body.decode('utf-8')))
+                    elif content_type == 'multipart/form-data':
+                        # TODO: Stream this instead of reading to/from memory
+                        boundary = parameters['boundary'].encode('utf-8')
+                        self.parsed_form, self.parsed_files = (
+                            parse_multipart_form(self.body, boundary))
+                except Exception as e:
+                    log.exception(e)
+                    pass
 
         return self.parsed_form
 


### PR DESCRIPTION
I have code like this:
```
form = RegistrationForm(request.form)
if request.method == 'POST' and form.validate():
    # do some stuff
return ...
```

But it raise:
```
Error: Can't convert 'NoneType' object to str implicitly
Exception: Traceback (most recent call last):
  File "/Users/pahaz/.virtualenvs/cross-social-science/lib/python3.5/site-packages/sanic/sanic.py", line 178, in handle_request
    response = await response
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/asyncio/coroutines.py", line 105, in __next__
    return self.gen.send(None)
  File "/Users/pahaz/PycharmProjects/ructfe-2016/services/cross-social-science/_buisness_views/registration.py", line 25, in registration
    form = RegistrationForm(request.form or None)
  File "/Users/pahaz/.virtualenvs/cross-social-science/lib/python3.5/site-packages/sanic/request.py", line 74, in form
    self.headers.get('Content-Type'))
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/cgi.py", line 319, in parse_header
    parts = _parseparam(';' + line)
TypeError: Can't convert 'NoneType' object to str implicitly
```

I just add the `content_type` validation.

From RFC:
> Any HTTP/1.1 message containing an entity-body SHOULD include a Content-Type header field defining the media type of that body. If and only if the media type is not given by a Content-Type field, the recipient MAY attempt to guess the media type via inspection of its content and/or the name extension(s) of the URI used to identify the resource. If the media type remains unknown, the recipient SHOULD treat it as type "application/octet-stream".

I don't know how-to `attempt to guess the media type via inspection of its content and/or the name extension(s) of the URI used to identify the resource`. I think in this case we must determine content type as `"application/octet-stream"`.

What do you think about that?

I am also set the `parsed_form` and `parsed_files` to `RequestParameters` type. Previously, in case of parsing error cases it set to `dict` type.
