### PR TITLE
Add the client address to the request header

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -116,7 +116,7 @@ class HttpProtocol(asyncio.Protocol):
     def on_headers_complete(self):
         ra = self.transport.get_extra_info('peername')
         if ra:
-             self.headers.append(('Remote-Addr','%s:%s' % ra))
+            self.headers.append(('Remote-Addr', '%s:%s' % ra))
 
         self.request = Request(
             url_bytes=self.url,

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -114,11 +114,10 @@ class HttpProtocol(asyncio.Protocol):
         self.headers.append((name.decode(), value.decode('utf-8')))
 
     def on_headers_complete(self):
-
         ra = self.transport.get_extra_info('peername')
         if ra:
              self.headers.append(('Remote-Addr','%s:%s' % ra))
-                     
+
         self.request = Request(
             url_bytes=self.url,
             headers=dict(self.headers),

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -114,6 +114,11 @@ class HttpProtocol(asyncio.Protocol):
         self.headers.append((name.decode(), value.decode('utf-8')))
 
     def on_headers_complete(self):
+
+        ra = self.transport.get_extra_info('peername')
+        if ra:
+             self.headers.append(('Remote-Addr','%s:%s' % ra))
+                     
         self.request = Request(
             url_bytes=self.url,
             headers=dict(self.headers),

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -114,9 +114,9 @@ class HttpProtocol(asyncio.Protocol):
         self.headers.append((name.decode(), value.decode('utf-8')))
 
     def on_headers_complete(self):
-        ra = self.transport.get_extra_info('peername')
-        if ra:
-            self.headers.append(('Remote-Addr', '%s:%s' % ra))
+        remote_addr = self.transport.get_extra_info('peername')
+        if remote_addr:
+            self.headers.append(('Remote-Addr', '%s:%s' % remote_addr))
 
         self.request = Request(
             url_bytes=self.url,


### PR DESCRIPTION
I expected the remote_addr in the Request object but it wasn't there. 
We use the remote ip address extensively for access control and logging.
This PR adds it to the header so we can migrate some services to Sanic.