### PR TITLE
aiohttp is slightly faster actually

### DIFF
--- a/tests/performance/aiohttp/simple_server.py
+++ b/tests/performance/aiohttp/simple_server.py
@@ -15,4 +15,4 @@ async def handle(request):
 app = web.Application(loop=loop)
 app.router.add_route('GET', '/', handle)
 
-web.run_app(app, port=sys.argv[1])
+web.run_app(app, port=sys.argv[1], access_log=None)


### PR DESCRIPTION
Disabling access log increases RPS a lot.

aiohttp shows 6K RPS with this change.

It's still much slower than sanic but faster than, say, flask.

P.S. no aiohttp changes in HTTP parsing like switching to httptools, just access log disabling.