### PR TITLE
Disable access log for aiohttp benchmark

### DIFF
--- a/tests/performance/aiohttp/simple_server.py
+++ b/tests/performance/aiohttp/simple_server.py
@@ -15,4 +15,4 @@ async def handle(request):
 app = web.Application(loop=loop)
 app.router.add_route('GET', '/', handle)
 
-web.run_app(app, port=sys.argv[1])
+web.run_app(app, port=int(sys.argv[1]), access_log=None)


### PR DESCRIPTION
Actually aiohttp server is more than two times faster than measured by sanic value.