### PR TITLE
Example for using error_handler

### DIFF
--- a/examples/exception_monitoring.py
+++ b/examples/exception_monitoring.py
@@ -1,0 +1,59 @@
+"""
+Example intercepting uncaught exceptions using Sanic's error handler framework.
+
+This may be useful for developers wishing to use Sentry, Airbrake, etc.
+or a custom system to log and monitor unexpected errors in production.
+
+First we create our own class inheriting from Handler in sanic.exceptions,
+and pass in an instance of it when we create our Sanic instance. Inside this
+class' default handler, we can do anything including sending exceptions to
+an external service.
+"""
+
+
+
+"""
+Imports and code relevant for our CustomHandler class
+(Ordinarily this would be in a separate file)
+"""
+from sanic.response import text
+from sanic.exceptions import Handler, SanicException
+
+class CustomHandler(Handler):
+    def default(self, request, exception):
+        # Here, we have access to the exception object
+        # and can do anything with it (log, send to external service, etc)
+
+        # Some exceptions are trivial and built into Sanic (404s, etc)
+        if not issubclass(type(exception), SanicException):
+            print(exception)
+
+        # Then, we must finish handling the exception by
+        # returning our response to the client
+        return text("An error occured", status=500)
+
+
+
+
+"""
+This is an ordinary Sanic server, with the exception that we set the
+server's error_handler to an instance of our CustomHandler
+"""
+
+from sanic import Sanic
+from sanic.response import json
+
+app = Sanic(__name__)
+
+handler = CustomHandler(sanic=app)
+app.error_handler = handler
+
+@app.route("/")
+async def test(request):
+    # Here, something occurs which causes an unexpected exception
+    # This exception will flow to our custom handler.
+    x = 1 / 0
+    return json({"test": True})
+
+
+app.run(host="0.0.0.0", port=8000)

--- a/examples/exception_monitoring.py
+++ b/examples/exception_monitoring.py
@@ -28,9 +28,10 @@ class CustomHandler(Handler):
         if not issubclass(type(exception), SanicException):
             print(exception)
 
-        # Then, we must finish handling the exception by
-        # returning our response to the client
-        return text("An error occured", status=500)
+        # Then, we must finish handling the exception by returning
+        # our response to the client
+        # For this we can just call the super class' default handler
+        return super.default(self, request, exception)
 
 
 
@@ -56,4 +57,4 @@ async def test(request):
     return json({"test": True})
 
 
-app.run(host="0.0.0.0", port=8000)
+app.run(host="0.0.0.0", port=8000, debug=True)


### PR DESCRIPTION
I did not realize Sanic had this functionality built it and assumed that it would be a major roadblock to generalized exception monitoring. This example would have saved a lot of time! Eventually hopefully we can get plugins for Sentry and the like.