### PR TITLE
Fix the flake8 error caused by new flake8 version

### DIFF
--- a/sanic/cookies.py
+++ b/sanic/cookies.py
@@ -30,6 +30,7 @@ def _quote(str):
     else:
         return '"' + str.translate(_Translator) + '"'
 
+
 _is_legal_key = re.compile('[%s]+' % re.escape(_LegalChars)).fullmatch
 
 # ------------------------------------------------------------ #


### PR DESCRIPTION
New versions of flake8 have introduced new rules causing new flake8 errors and raising false negatives on our gate job.