### PR TITLE
provide default app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All tests were run on an AWS medium instance running ubuntu, using 1 process.  E
 from sanic import Sanic
 from sanic.response import json
 
-app = Sanic(__name__)
+app = Sanic()
 
 @app.route("/")
 async def test(request):

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -1,7 +1,7 @@
 from asyncio import get_event_loop
 from collections import deque
 from functools import partial
-from inspect import isawaitable
+from inspect import isawaitable, stack, getmodulename
 from multiprocessing import Process, Event
 from signal import signal, SIGTERM, SIGINT
 from time import sleep
@@ -18,7 +18,10 @@ from .exceptions import ServerError
 
 
 class Sanic:
-    def __init__(self, name, router=None, error_handler=None):
+    def __init__(self, name=None, router=None, error_handler=None):
+        if name is None:
+            frame_records = stack()[1]
+            name = getmodulename(frame_records[1])
         self.name = name
         self.router = router or Router()
         self.error_handler = error_handler or Handler(self)


### PR DESCRIPTION
This allows instantiating the Sanic object without providing an app name:

```
from sanic import Sanic
from sanic.response import json

app = Sanic()

@app.route("/")
async def test(request):
    return json({"hello": "world"})

app.run(host="0.0.0.0", port=8000)
```