### PR TITLE
fix the way using logging.exception

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -67,7 +67,7 @@ class Request:
             try:
                 self.parsed_json = json_loads(self.body)
             except Exception:
-                pass
+                log.exception("failed when parsing body as json")
 
         return self.parsed_json
 
@@ -88,9 +88,9 @@ class Request:
                     boundary = parameters['boundary'].encode('utf-8')
                     self.parsed_form, self.parsed_files = (
                         parse_multipart_form(self.body, boundary))
-            except Exception as e:
-                log.exception(e)
-                pass
+            except Exception:
+                log.exception("failed when parsing form")
+
         return self.parsed_form
 
     @property

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -295,8 +295,7 @@ class Sanic:
 
         except Exception as e:
             log.exception(
-                'Experienced exception while trying to serve: {}'.format(e))
-            pass
+                'Experienced exception while trying to serve')
 
         log.info("Server Stopped")
 


### PR DESCRIPTION
it seems that the way we're using `logging.exception` is a little bit wrong.

https://docs.python.org/3/library/logging.html#logging.Logger.exception

`logging.exception` will record the exceptions, so what we need to do is fill-in some messages.