### PR TITLE
provide initialized class for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,14 @@ All tests were run on an AWS medium instance running ubuntu, using 1 process.  E
 ## Hello World
 
 ```python
-from sanic import Sanic
+from sanic import sanic
 from sanic.response import json
 
-app = Sanic()
-
-@app.route("/")
+@sanic.route("/")
 async def test(request):
     return json({"hello": "world"})
 
-app.run(host="0.0.0.0", port=8000)
+sanic.run(host="0.0.0.0", port=8000)
 ```
 
 ## Installation

--- a/sanic/__init__.py
+++ b/sanic/__init__.py
@@ -1,6 +1,8 @@
 from .sanic import Sanic
 from .blueprints import Blueprint
 
+sanic = Sanic()
+
 __version__ = '0.1.7'
 
 __all__ = ['Sanic', 'Blueprint']


### PR DESCRIPTION
This makes usage more compact and still supports the old style of importing and instantiating the `Sanic` class directly.