### PR TITLE
Convert server lambda to partial

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -235,14 +235,23 @@ def serve(host, port, request_handler, before_start=None, after_start=None,
 
     connections = {}
     signal = Signal()
-    server_coroutine = loop.create_server(lambda: HttpProtocol(
+    server = partial(
+        HttpProtocol,
         loop=loop,
         connections=connections,
         signal=signal,
         request_handler=request_handler,
         request_timeout=request_timeout,
         request_max_size=request_max_size,
-    ), host, port, reuse_port=reuse_port, sock=sock)
+    )
+
+    server_coroutine = loop.create_server(
+        server,
+        host,
+        port,
+        reuse_port=reuse_port,
+        sock=sock
+    )
 
     # Instead of pulling time at the end of every request,
     # pull it once per minute


### PR DESCRIPTION
Partials are faster then lambdas for repeated calls.