### PR TITLE
fix for cookie header capitalization bug

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -114,11 +114,10 @@ class Request(dict):
     @property
     def cookies(self):
         if self._cookies is None:
-            if 'cookie' in self.headers: #HTTP2 cookie header
-                self.headers['Cookie'] = self.headers.pop('cookie')
-            if 'Cookie' in self.headers:
+            cookie = self.headers.get('Cookie') or self.headers.get('cookie')
+            if cookie is not None:
                 cookies = SimpleCookie()
-                cookies.load(self.headers['Cookie'])
+                cookies.load(cookie)
                 self._cookies = {name: cookie.value
                                  for name, cookie in cookies.items()}
             else:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -114,6 +114,8 @@ class Request(dict):
     @property
     def cookies(self):
         if self._cookies is None:
+            if 'cookie' in self.headers: #HTTP2 cookie header
+                self.headers['Cookie'] = self.headers.pop('cookie')
             if 'Cookie' in self.headers:
                 cookies = SimpleCookie()
                 cookies.load(self.headers['Cookie'])

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -25,6 +25,19 @@ def test_cookies():
     assert response.text == 'Cookies are: working!'
     assert response_cookies['right_back'].value == 'at you'
 
+def test_http2_cookies():
+    app = Sanic('test_http2_cookies')
+
+    @app.route('/')
+    async def handler(request):
+        response = text('Cookies are: {}'.format(request.cookies['test']))
+        return response
+
+    headers = {'cookie': 'test=working!'}
+    request, response = sanic_endpoint_test(app, headers=headers)
+
+    assert response.text == 'Cookies are: working!'
+
 def test_cookie_options():
     app = Sanic('test_text')
 


### PR DESCRIPTION
Just spent a week with cloudflare support trying to figure out why cookies seem to vanish under some conditions with sanic - it seems like an [issue](http://httpwg.org/specs/rfc7540.html#CompressCookie) with HTTP2. 

There might be a more elegant way to do this or a way the maintainers would prefer. I wanted to get this to your attention right away as this could definitely be a really hard to diagnose problem for some people.