### PR TITLE
Find URL encoded filenames on the fs by decoding them first

### DIFF
--- a/sanic/static.py
+++ b/sanic/static.py
@@ -33,12 +33,14 @@ def register(app, uri, file_or_directory, pattern, use_modified_since):
         # served.  os.path.realpath seems to be very slow
         if file_uri and '../' in file_uri:
             raise InvalidUsage("Invalid URL")
-
+            
         # Merge served directory and requested file if provided
         # Strip all / that in the beginning of the URL to help prevent python
         # from herping a derp and treating the uri as an absolute path
-        file_path = path.join(file_or_directory, sub('^[/]*', '', file_uri)) \
-            if file_uri else file_or_directory
+        file_path = file_or_directory
+        if file_uri:
+            file_path = path.join(
+                file_or_directory, sub('^[/]*', '', file_uri))
 
         # URL decode the path sent by the browser otherwise we won't be able to
         # match filenames which got encoded (filenames with spaces etc)

--- a/sanic/static.py
+++ b/sanic/static.py
@@ -40,6 +40,8 @@ def register(app, uri, file_or_directory, pattern, use_modified_since):
         file_path = path.join(file_or_directory, sub('^[/]*', '', file_uri)) \
             if file_uri else file_or_directory
 
+        # URL decode the path sent by the browser otherwise we won't be able to 
+        # match filenames which got encoded (filenames with spaces etc)
         file_path = unquote(file_path)
         try:
             headers = {}

--- a/sanic/static.py
+++ b/sanic/static.py
@@ -2,6 +2,7 @@ from aiofiles.os import stat
 from os import path
 from re import sub
 from time import strftime, gmtime
+from urllib.parse import unquote
 
 from .exceptions import FileNotFound, InvalidUsage
 from .response import file, HTTPResponse
@@ -38,6 +39,8 @@ def register(app, uri, file_or_directory, pattern, use_modified_since):
         # from herping a derp and treating the uri as an absolute path
         file_path = path.join(file_or_directory, sub('^[/]*', '', file_uri)) \
             if file_uri else file_or_directory
+
+        file_path = unquote(file_path)
         try:
             headers = {}
             # Check if the client has been sent this file before

--- a/sanic/static.py
+++ b/sanic/static.py
@@ -40,7 +40,7 @@ def register(app, uri, file_or_directory, pattern, use_modified_since):
         file_path = path.join(file_or_directory, sub('^[/]*', '', file_uri)) \
             if file_uri else file_or_directory
 
-        # URL decode the path sent by the browser otherwise we won't be able to 
+        # URL decode the path sent by the browser otherwise we won't be able to
         # match filenames which got encoded (filenames with spaces etc)
         file_path = unquote(file_path)
         try:

--- a/sanic/static.py
+++ b/sanic/static.py
@@ -33,7 +33,6 @@ def register(app, uri, file_or_directory, pattern, use_modified_since):
         # served.  os.path.realpath seems to be very slow
         if file_uri and '../' in file_uri:
             raise InvalidUsage("Invalid URL")
-            
         # Merge served directory and requested file if provided
         # Strip all / that in the beginning of the URL to help prevent python
         # from herping a derp and treating the uri as an absolute path


### PR DESCRIPTION
As-is sanic returns a 404 for files which are requested with a space in their filename.
This due to the browser url-encoding them first. By decoding the filename we make sure the file is actually found.