### PR TITLE
url params docs typo fix

### DIFF
--- a/docs/class_based_views.md
+++ b/docs/class_based_views.md
@@ -39,6 +39,6 @@ class NameView(HTTPMethodView):
   def get(self, request, name):
     return text('Hello {}'.format(name))
 
-app.add_route(NameView(), '/<name')
+app.add_route(NameView(), '/<name>')
 
 ```


### PR DESCRIPTION
add missing '>' in url params docs example