### PR TITLE
Fix PEP8 in Hello World example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ All tests were run on an AWS medium instance running ubuntu, using 1 process.  E
 from sanic import Sanic
 from sanic.response import json
 
+
 app = Sanic()
+
 
 @app.route("/")
 async def test(request):
     return json({"hello": "world"})
 
-app.run(host="0.0.0.0", port=8000)
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", port=8000)
+
 ```
 
 ## Installation


### PR DESCRIPTION
I added a few things to make the "Hello World" example a bit cleaner and conform to PEP8, since it will be everyone's first experience with Sanic. 

These include: an extra line between the imports and the rest of code, as well as before the test function. I also added a check whether the module is being run as a standard program and a blank line at the end of the file.