### PR TITLE
Fixed import error in docs

### DIFF
--- a/docs/class_based_views.md
+++ b/docs/class_based_views.md
@@ -6,6 +6,7 @@ Sanic has simple class based implementation. You should implement methods(get, p
 ```python
 from sanic import Sanic
 from sanic.views import HTTPMethodView
+from sanic.response import text
 
 app = Sanic('some_name')
 


### PR DESCRIPTION
sanic.response.text is being used as a return object. Let's import it for sake of clarity. 