### PR TITLE
Added features to do Sanic more plugable

### DIFF
--- a/sanic/__init__.py
+++ b/sanic/__init__.py
@@ -1,6 +1,6 @@
 from .sanic import Sanic
 from .blueprints import Blueprint
 
-__version__ = '0.1.8'
+__version__ = '0.1.9'
 
 __all__ = ['Sanic', 'Blueprint']

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -39,13 +39,14 @@ class Request(dict):
     """
     __slots__ = (
         'url', 'headers', 'version', 'method', '_cookies',
-        'query_string', 'body',
+        'query_string', 'body', 'app', 'handler',
         'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
     )
 
-    def __init__(self, url_bytes, headers, version, method):
+    def __init__(self, url_bytes, headers, version, method, app):
         # TODO: Content-Encoding detection
         url_parsed = parse_url(url_bytes)
+        self.app = app
         self.url = url_parsed.path.decode('utf-8')
         self.headers = headers
         self.version = version

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -79,7 +79,9 @@ class HTTPResponse:
         self.content_type = content_type
 
         if body is not None:
-            self.body = body.encode('utf-8')
+            self.body = body
+            if type(body) is str:
+                self.body = body.encode('utf-8')
         else:
             self.body = body_bytes
 

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -110,8 +110,11 @@ class Sanic:
             attach_to = args[0]
             return register_middleware
 
-    def add_middleware(self, *args, **kwargs):
-        self.middleware(*args, **kwargs)
+    def add_middleware(self, middleware, attach_to="request"):
+        if attach_to == 'request':
+            self.request_middleware.append(middleware)
+        if attach_to == 'response':
+            self.response_middleware.append(middleware)
 
     # Static Files
     def static(self, uri, file_or_directory, pattern='.+',

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -112,7 +112,7 @@ class Sanic:
 
     def add_middleware(self, *args, **kwargs):
         self.middleware(*args, **kwargs)
-    
+
     # Static Files
     def static(self, uri, file_or_directory, pattern='.+',
                use_modified_since=True):
@@ -164,13 +164,13 @@ class Sanic:
         :return: Nothing
         """
         try:
-            
+
             # Fetch handler from router
             handler, args, kwargs = self.router.get(request)
-            
+
             # Add view handler
             request.handler = handler
-            
+
             # -------------------------------------------- #
             # Request Middleware
             # -------------------------------------------- #

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -110,6 +110,9 @@ class Sanic:
             attach_to = args[0]
             return register_middleware
 
+    def add_middleware(self, *args, **kwargs):
+        self.middleware(*args, **kwargs)
+    
     # Static Files
     def static(self, uri, file_or_directory, pattern='.+',
                use_modified_since=True):
@@ -161,6 +164,13 @@ class Sanic:
         :return: Nothing
         """
         try:
+            
+            # Fetch handler from router
+            handler, args, kwargs = self.router.get(request)
+            
+            # Add view handler
+            request.handler = handler
+            
             # -------------------------------------------- #
             # Request Middleware
             # -------------------------------------------- #
@@ -181,8 +191,6 @@ class Sanic:
                 # Execute Handler
                 # -------------------------------------------- #
 
-                # Fetch handler from router
-                handler, args, kwargs = self.router.get(request)
                 if handler is None:
                     raise ServerError(
                         ("'None' was returned while requesting a "
@@ -266,7 +274,8 @@ class Sanic:
             'error_handler': self.error_handler,
             'request_timeout': self.config.REQUEST_TIMEOUT,
             'request_max_size': self.config.REQUEST_MAX_SIZE,
-            'loop': loop
+            'loop': loop,
+            'app': self
         }
 
         # -------------------------------------------- #

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -29,15 +29,16 @@ class HttpProtocol(asyncio.Protocol):
         # event loop, connection
         'loop', 'transport', 'connections', 'signal',
         # request params
-        'parser', 'request', 'url', 'headers',
+        'parser', 'request', 'url', 'headers', 'app',
         # request config
         'request_handler', 'request_timeout', 'request_max_size',
         # connection management
         '_total_request_size', '_timeout_handler', '_last_communication_time')
 
-    def __init__(self, *, loop, request_handler, error_handler,
+    def __init__(self, *, loop, request_handler, error_handler, app,
                  signal=Signal(), connections={}, request_timeout=60,
                  request_max_size=None):
+        self.app = app
         self.loop = loop
         self.transport = None
         self.request = None
@@ -128,7 +129,8 @@ class HttpProtocol(asyncio.Protocol):
             url_bytes=self.url,
             headers=CIMultiDict(self.headers),
             version=self.parser.get_http_version(),
-            method=self.parser.get_method().decode()
+            method=self.parser.get_method().decode(),
+            app=self.app
         )
 
     def on_body(self, body):
@@ -224,7 +226,7 @@ def trigger_events(events, loop):
 def serve(host, port, request_handler, error_handler, before_start=None,
           after_start=None, before_stop=None, after_stop=None,
           debug=False, request_timeout=60, sock=None,
-          request_max_size=None, reuse_port=False, loop=None):
+          request_max_size=None, reuse_port=False, loop=None, app=None):
     """
     Starts asynchronous HTTP Server on an individual process.
     :param host: Address to host on
@@ -240,6 +242,7 @@ def serve(host, port, request_handler, error_handler, before_start=None,
     :param request_max_size: size in bytes, `None` for no limit
     :param reuse_port: `True` for multiple workers
     :param loop: asyncio compatible event loop
+    :param app: Sanic instance.
     :return: Nothing
     """
     loop = loop or async_loop.new_event_loop()
@@ -261,6 +264,7 @@ def serve(host, port, request_handler, error_handler, before_start=None,
         error_handler=error_handler,
         request_timeout=request_timeout,
         request_max_size=request_max_size,
+        app=app
     )
 
     server_coroutine = loop.create_server(


### PR DESCRIPTION
This PR try to add some features that already exists in other frameworks (like aiohttp) and that are useful for the plugin development:
- add te "app" property into each request, with te Sanic instances 
- add the property "handler" in each request, that contains the view handed where the request was originated 
- new method to add a middleware: add_middelware

The features do not affect to the performance (I was tested) and the could be very useful try to grow the framework.

request.py
----------

add: new property: 'app'. This property contains an instance of Sanic application.
add: new property: 'handler'. This property will be setted before a request is sent to the view or middleware and contains the handler of view. This is useful to know all information of view, for example: if any plugin decorates the function, only in runtime the middleware or view will know this information. The most common case is when we want to decorate a view o use a cache system. The middleware must know who view are marked as a cached.

sanic.py
--------

add: new method to append a middleware. The idea is to set middleware easily, thinking in possible plugins. Using this way, a plugin could use this method to add their custom middleware. For example: An authentication system or cache.
modified: reordered the the call of "self.router.get(...)", to add the "handler" property to the request before any middleware is called.

server.py
---------

add: app instance in constructors