### PR TITLE
Rewrite static files tests

### DIFF
--- a/tests/static/decode me.txt
+++ b/tests/static/decode me.txt
@@ -1,0 +1,1 @@
+I need to be decoded as a uri

--- a/tests/static/test.file
+++ b/tests/static/test.file
@@ -1,0 +1,1 @@
+I am just a regular static file

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,30 +1,62 @@
 import inspect
 import os
 
+import pytest
+
 from sanic import Sanic
 from sanic.utils import sanic_endpoint_test
 
-def test_static_file():
-    current_file = inspect.getfile(inspect.currentframe())
-    with open(current_file, 'rb') as file:
-        current_file_contents = file.read()
 
+@pytest.fixture(scope='module')
+def static_file_directory():
+    """The static directory to serve"""
+    current_file = inspect.getfile(inspect.currentframe())
+    current_directory = os.path.dirname(os.path.abspath(current_file))
+    static_directory = os.path.join(current_directory, 'static')
+    return static_directory
+
+
+@pytest.fixture(scope='module')
+def static_file_path(static_file_directory):
+    """The path to the static file that we want to serve"""
+    return os.path.join(static_file_directory, 'test.file')
+
+
+@pytest.fixture(scope='module')
+def static_file_content(static_file_path):
+    """The content of the static file to check"""
+    with open(static_file_path, 'rb') as file:
+        return file.read()
+
+
+def test_static_file(static_file_path, static_file_content):
     app = Sanic('test_static')
-    app.static('/testing.file', current_file)
+    app.static('/testing.file', static_file_path)
 
     request, response = sanic_endpoint_test(app, uri='/testing.file')
     assert response.status == 200
-    assert response.body == current_file_contents
+    assert response.body == static_file_content
 
-def test_static_directory():
-    current_file = inspect.getfile(inspect.currentframe())
-    current_directory = os.path.dirname(os.path.abspath(current_file))
-    with open(current_file, 'rb') as file:
-        current_file_contents = file.read()
+
+def test_static_directory(
+        static_file_directory, static_file_path, static_file_content):
 
     app = Sanic('test_static')
-    app.static('/dir', current_directory)
+    app.static('/dir', static_file_directory)
 
-    request, response = sanic_endpoint_test(app, uri='/dir/test_static.py')
+    request, response = sanic_endpoint_test(app, uri='/dir/test.file')
     assert response.status == 200
-    assert response.body == current_file_contents
+    assert response.body == static_file_content
+
+
+def test_static_url_decode_file(static_file_directory):
+    decode_me_path = os.path.join(static_file_directory, 'decode me.txt')
+    with open(decode_me_path, 'rb') as file:
+        decode_me_contents = file.read()
+
+    app = Sanic('test_static')
+    app.static('/dir', static_file_directory)
+
+    request, response = sanic_endpoint_test(app, uri='/dir/decode me.txt')
+    assert response.status == 200
+    assert response.body == decode_me_contents


### PR DESCRIPTION
Relates to PR #188

## Changes include:
* Rewriting to work with pytest fixtures and an actual static directory
* Addition of a test that covers file paths that must be
   unquoted as a uri

## NOTE:
* unquoting is only applicable for when you are serving a directory, any attempt to serve a static file with a uri that includes anything that needs to be unquoted will result in a 404