### PR TITLE
Refactor write_error()

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -160,8 +160,9 @@ class HttpProtocol(asyncio.Protocol):
                 self._last_request_time = current_time
                 self.cleanup()
         except Exception as e:
-            self.bail_out(
-                "Writing response failed, connection closed {}".format(e))
+            exception = ServerError(
+                    'Writing response failed, connection closed {}'.format(e))
+            self.write_error(exception)
 
     def write_error(self, exception):
         try:
@@ -170,13 +171,9 @@ class HttpProtocol(asyncio.Protocol):
             self.transport.write(response.output(version))
             self.transport.close()
         except Exception as e:
-            self.bail_out(
-                "Writing error failed, connection closed {}".format(e))
-
-    def bail_out(self, message):
-        exception = ServerError(message)
-        self.write_error(exception)
-        log.error(message)
+            self.transport.close()
+            log.error(
+                'Writing error failed, connection closed {}'.format(e))
 
     def cleanup(self):
         self.parser = None

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -49,6 +49,25 @@ def test_invalid_response():
     assert response.text == "Internal Server Error."
 
 
+def test_error_in_write_error():
+    app = Sanic('error_in_write_error')
+
+    @app.exception(ServerError)
+    def handler_exception(request, exception):
+        return 'This should fail'
+
+    @app.route('/')
+    async def handler(request):
+        return 'This should fail'
+
+    try:
+        _ = sanic_endpoint_test(app, gather_request=False)
+    except ValueError as e:
+        assert e.args[0] == 'Exception during request: [ClientResponseError()]'
+    else:
+        raise Exception()
+
+
 def test_json():
     app = Sanic('test_json')
 


### PR DESCRIPTION
When an error occurs in write_error(), process cycles bail_out() and write_error().
This behavior  is not appropriate.

Change:
This closes transport and writes log when an error occurs in write_error(). 

