### PR TITLE
Add invalid response object error handling

### DIFF
--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -21,6 +21,10 @@ class ServerError(SanicException):
     status_code = 500
 
 
+class InvalidResponseObject(SanicException):
+    status_code = 500
+
+
 class FileNotFound(NotFound):
     status_code = 404
 

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -6,7 +6,7 @@ from signal import SIGINT, SIGTERM
 from time import time
 from httptools import HttpRequestParser
 from httptools.parser.errors import HttpParserError
-from .exceptions import ServerError
+from .exceptions import ServerError, InvalidResponseObject
 
 try:
     import uvloop as async_loop
@@ -150,9 +150,14 @@ class HttpProtocol(asyncio.Protocol):
         try:
             keep_alive = self.parser.should_keep_alive() \
                             and not self.signal.stopped
-            self.transport.write(
-                response.output(
-                    self.request.version, keep_alive, self.request_timeout))
+            try:
+                self.transport.write(
+                    response.output(
+                        self.request.version, keep_alive,
+                        self.request_timeout))
+            except AttributeError:
+                raise InvalidResponseObject(
+                    'Invalid response object, must be of type HTTPResponse')
             if not keep_alive:
                 self.transport.close()
             else:


### PR DESCRIPTION
Relates to #231 in that this PR will handle errors when a developer makes a route that does not return an HTTPResponse type object.

In that event the caller to the URI and the logs will reflect that an HTTPResponse object is needed.