### PR TITLE
Add token property to request

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 class BlueprintSetup:
     """
+    Creates a blueprint state like object.
     """
 
     def __init__(self, blueprint, app, options):
@@ -29,13 +30,13 @@ class BlueprintSetup:
 
     def add_exception(self, handler, *args, **kwargs):
         """
-        Registers exceptions to sanic
+        Registers exceptions to sanic.
         """
         self.app.exception(*args, **kwargs)(handler)
 
     def add_static(self, uri, file_or_directory, *args, **kwargs):
         """
-        Registers static files to sanic
+        Registers static files to sanic.
         """
         if self.url_prefix:
             uri = self.url_prefix + uri
@@ -44,7 +45,7 @@ class BlueprintSetup:
 
     def add_middleware(self, middleware, *args, **kwargs):
         """
-        Registers middleware to sanic
+        Registers middleware to sanic.
         """
         if args or kwargs:
             self.app.middleware(*args, **kwargs)(middleware)
@@ -73,11 +74,13 @@ class Blueprint:
 
     def make_setup_state(self, app, options):
         """
+        Returns a new BlueprintSetup object
         """
         return BlueprintSetup(self, app, options)
 
     def register(self, app, options):
         """
+        Registers the blueprint to the sanic app.
         """
         state = self.make_setup_state(app, options)
         for deferred in self.deferred_functions:
@@ -85,6 +88,9 @@ class Blueprint:
 
     def route(self, uri, methods=None):
         """
+        Creates a blueprint route from a decorated function.
+        :param uri: Endpoint at which the route will be accessible.
+        :param methods: List of acceptable HTTP methods.
         """
         def decorator(handler):
             self.record(lambda s: s.add_route(handler, uri, methods))
@@ -93,12 +99,18 @@ class Blueprint:
 
     def add_route(self, handler, uri, methods=None):
         """
+        Creates a blueprint route from a function.
+        :param handler: Function to handle uri request.
+        :param uri: Endpoint at which the route will be accessible.
+        :param methods: List of acceptable HTTP methods.
         """
         self.record(lambda s: s.add_route(handler, uri, methods))
         return handler
 
     def listener(self, event):
         """
+        Create a listener from a decorated function.
+        :param event: Event to listen to.
         """
         def decorator(listener):
             self.listeners[event].append(listener)
@@ -107,6 +119,7 @@ class Blueprint:
 
     def middleware(self, *args, **kwargs):
         """
+        Creates a blueprint middleware from a decorated function.
         """
         def register_middleware(middleware):
             self.record(
@@ -123,6 +136,7 @@ class Blueprint:
 
     def exception(self, *args, **kwargs):
         """
+        Creates a blueprint exception from a decorated function.
         """
         def decorator(handler):
             self.record(lambda s: s.add_exception(handler, *args, **kwargs))
@@ -131,6 +145,9 @@ class Blueprint:
 
     def static(self, uri, file_or_directory, *args, **kwargs):
         """
+        Creates a blueprint static route from a decorated function.
+        :param uri: Endpoint at which the route will be accessible.
+        :param file_or_directory: Static asset.
         """
         self.record(
             lambda s: s.add_static(uri, file_or_directory, *args, **kwargs))

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -8,8 +8,9 @@ from sanic.exceptions import InvalidUsage
 
 from .log import log
 
-
 DEFAULT_HTTP_CONTENT_TYPE = "application/octet-stream"
+
+
 # HTTP/1.1: https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1
 # > If the media type remains unknown, the recipient SHOULD treat it
 # > as type "application/octet-stream"
@@ -71,6 +72,17 @@ class Request(dict):
                 raise InvalidUsage("Failed when parsing body as json")
 
         return self.parsed_json
+
+    @property
+    def token(self):
+        """
+        Attempts to return the auth header token.
+        :return: token related to request
+        """
+        auth_header = self.headers.get('Authorization', None)
+        if auth_header is not None:
+            return auth_header.split()[1]
+        return auth_header
 
     @property
     def form(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -79,7 +79,7 @@ class Request(dict):
         Attempts to return the auth header token.
         :return: token related to request
         """
-        auth_header = self.headers.get('Authorization', None)
+        auth_header = self.headers.get('Authorization')
         if auth_header is not None:
             return auth_header.split()[1]
         return auth_header

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -140,7 +140,7 @@ class HTTPResponse:
 
 def json(body, status=200, headers=None):
     """
-    Returns body in json format.
+    Returns response object with body in json format.
     :param body: Response data to be serialized.
     :param status: Response code.
     :param headers: Custom Headers.
@@ -151,7 +151,7 @@ def json(body, status=200, headers=None):
 
 def text(body, status=200, headers=None):
     """
-    Returns body in text format.
+    Returns response object with body in text format.
     :param body: Response data to be encoded.
     :param status: Response code.
     :param headers: Custom Headers.
@@ -162,7 +162,7 @@ def text(body, status=200, headers=None):
 
 def html(body, status=200, headers=None):
     """
-    Returns body in html format.
+    Returns response object with body in html format.
     :param body: Response data to be encoded.
     :param status: Response code.
     :param headers: Custom Headers.
@@ -173,7 +173,7 @@ def html(body, status=200, headers=None):
 
 async def file(location, mime_type=None, headers=None):
     """
-    Returns file with mime_type.
+    Returns response object with file data.
     :param location: Location of file on system.
     :param mime_type: Specific mime_type.
     :param headers: Custom Headers.

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -139,21 +139,45 @@ class HTTPResponse:
 
 
 def json(body, status=200, headers=None):
+    """
+    Returns serialized python object to json format.
+    :param body: Response data to be serialized.
+    :param status: Response code.
+    :param headers: Custom Headers.
+    """
     return HTTPResponse(json_dumps(body), headers=headers, status=status,
                         content_type="application/json")
 
 
 def text(body, status=200, headers=None):
+    """
+    Returns body in text format.
+    :param body: Response data to be encoded.
+    :param status: Response code.
+    :param headers: Custom Headers.
+    """
     return HTTPResponse(body, status=status, headers=headers,
                         content_type="text/plain; charset=utf-8")
 
 
 def html(body, status=200, headers=None):
+    """
+    Returns body in html format.
+    :param body: Response data to be encoded.
+    :param status: Response code.
+    :param headers: Custom Headers.
+    """
     return HTTPResponse(body, status=status, headers=headers,
                         content_type="text/html; charset=utf-8")
 
 
 async def file(location, mime_type=None, headers=None):
+    """
+    Returns file with mime_type.
+    :param location: Location of file on system.
+    :param mime_type: Specific mime_type.
+    :param headers: Custom Headers.
+    """
     filename = path.split(location)[-1]
 
     async with open_async(location, mode='rb') as _file:

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -140,7 +140,7 @@ class HTTPResponse:
 
 def json(body, status=200, headers=None):
     """
-    Returns serialized python object to json format.
+    Returns body in json format.
     :param body: Response data to be serialized.
     :param status: Response code.
     :param headers: Custom Headers.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -119,11 +119,9 @@ def test_post_token():
     async def handler(request):
         return text('OK')
 
-    payload = {'test': 'OK'}
-
     # uuid4 generated token.
     token = 'a1d895e0-553a-421a-8e22-5ff8ecb48cbf'
-
+    payload = {'test': 'OK'}
     headers = {
         'content-type': 'application/json',
         'Authorization': 'Token {}'.format(token)
@@ -132,33 +130,6 @@ def test_post_token():
     request, response = sanic_endpoint_test(app, data=json_dumps(payload), headers=headers)
 
     assert request.token == token
-    assert response.text == 'OK'
-
-    # uuid4 generated token.
-    token = 'a1d895e0-553a-421a-8e22'
-
-    headers = {
-        'content-type': 'application/json',
-        'Authorization': 'Bearer {}'.format(token)
-    }
-
-    request, response = sanic_endpoint_test(app, data=json_dumps(payload), headers=headers)
-
-    assert request.token == token
-    assert response.text == 'OK'
-
-    # uuid4 generated token.
-    token = '421a-8e22-5ff8ecb48cbf'
-
-    headers = {
-        'content-type': 'application/json',
-        'Authorization': 'Basic {}'.format(token)
-    }
-
-    request, response = sanic_endpoint_test(app, data=json_dumps(payload), headers=headers)
-
-    assert request.token == token
-    assert response.text == 'OK'
 
 
 def test_post_form_urlencoded():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -134,6 +134,32 @@ def test_post_token():
     assert request.token == token
     assert response.text == 'OK'
 
+    # uuid4 generated token.
+    token = 'a1d895e0-553a-421a-8e22'
+
+    headers = {
+        'content-type': 'application/json',
+        'Authorization': 'Bearer {}'.format(token)
+    }
+
+    request, response = sanic_endpoint_test(app, data=json_dumps(payload), headers=headers)
+
+    assert request.token == token
+    assert response.text == 'OK'
+
+    # uuid4 generated token.
+    token = '421a-8e22-5ff8ecb48cbf'
+
+    headers = {
+        'content-type': 'application/json',
+        'Authorization': 'Basic {}'.format(token)
+    }
+
+    request, response = sanic_endpoint_test(app, data=json_dumps(payload), headers=headers)
+
+    assert request.token == token
+    assert response.text == 'OK'
+
 
 def test_post_form_urlencoded():
     app = Sanic('test_post_form_urlencoded')

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -112,6 +112,29 @@ def test_post_json():
     assert response.text == 'OK'
 
 
+def test_post_token():
+    app = Sanic('test_post_token')
+
+    @app.route('/')
+    async def handler(request):
+        return text('OK')
+
+    payload = {'test': 'OK'}
+
+    # uuid4 generated token.
+    token = 'a1d895e0-553a-421a-8e22-5ff8ecb48cbf'
+
+    headers = {
+        'content-type': 'application/json',
+        'Authorization': 'Token {}'.format(token)
+    }
+
+    request, response = sanic_endpoint_test(app, data=json_dumps(payload), headers=headers)
+
+    assert request.token == token
+    assert response.text == 'OK'
+
+
 def test_post_form_urlencoded():
     app = Sanic('test_post_form_urlencoded')
 


### PR DESCRIPTION
I added a `token` property to the request object which makes it easier to access the 'Authorization' header via `request.token`

``` py
    @property
    def token(self):
        """
        Attempts to return the auth header token.
        :return: token related to request
        """
        auth_header = self.headers.get('Authorization')
        if auth_header is not None:
            return auth_header.split()[1]
        return auth_header
```

The way it's set up is to work with common `Authorization` headers which normally put some text before the actual token like `Bearer`, `Basic` or `Token`. Regardless of what's in front of the actual token, it returns the token.


I added a test to confirm that it's working as intended.