### PR TITLE
Change travis job to use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - '3.5'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,8 @@ language: python
 python:
   - '3.5'
   - '3.6'
-install:
-  - pip install -r requirements.txt
-  - pip install -r requirements-dev.txt
-  - python setup.py install
-  - pip install flake8
-  - pip install pytest
-before_script: flake8 sanic
-script: py.test -v tests
+install: pip install tox-travis
+script: tox
 deploy:
   provider: pypi
   user: channelcat

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = py35, py36
+envlist = py35, py36, flake8, report
 
 [testenv]
 
@@ -26,6 +26,8 @@ commands =
     flake8 sanic
 
 [testenv:report]
+deps=
+    coverage
 
 commands =
     coverage combine

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,21 @@
 [tox]
 
-envlist = py35, py36, flake8, report
+envlist = py35, py36, flake8
+
+[travis]
+
+python =
+    3.5: py35, flake8
+    3.6: py36, flake8
 
 [testenv]
 
 deps =
     aiohttp
     pytest
-    coverage
 
 commands =
-    coverage run -m pytest -v tests {posargs}
-    mv .coverage .coverage.{envname}
-
-whitelist_externals =
-    coverage
-    mv
-    echo
+    pytest tests {posargs}
 
 [testenv:flake8]
 deps =
@@ -24,13 +23,3 @@ deps =
 
 commands =
     flake8 sanic
-
-[testenv:report]
-deps=
-    coverage
-
-commands =
-    coverage combine
-    coverage report
-    coverage html
-    echo "Open file://{toxinidir}/coverage/index.html"


### PR DESCRIPTION
We want to keep a consistent testing approach when it comes to Sanic, this change will make sure that we do.

To run tests now just use:
```console
$ tox
```

A pre-commit hook might also be written to block commits from being published until they run the tox job successfully.