### PR TITLE
Allow Sanic-inherited application

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
 
         module = import_module(module_name)
         app = getattr(module, app_name, None)
-        if type(app) is not Sanic:
+        if not isinstance(app, Sanic):
             raise ValueError("Module is not a Sanic app, it is a {}.  "
                              "Perhaps you meant {}.app?"
                              .format(type(app).__name__, args.module))


### PR DESCRIPTION
Motivation:
In my case I use custom Sanic-inherited class instance as app instance. and when it compares their type strictly I can't use python -m sanic [...] to run the server.

Changes:
Checking type via isinstnace() rather than type() is so the subclasses' one could be treated as its parent Sanic type instance.