### PR TITLE
Add token property to request

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -73,6 +73,17 @@ class Request(dict):
         return self.parsed_json
 
     @property
+    def token(self):
+        """
+        Attempts to return the auth header token.
+        :return: token related to request
+        """
+        auth_header = self.headers.get('Authorization')
+        if auth_header is not None:
+            return auth_header.split()[1]
+        return auth_header
+
+    @property
     def form(self):
         if self.parsed_form is None:
             self.parsed_form = RequestParameters()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -92,6 +92,24 @@ def test_query_string():
     assert request.args.get('test2') == 'false'
 
 
+def test_token():
+    app = Sanic('test_post_token')
+
+    @app.route('/')
+    async def handler(request):
+        return text('OK')
+
+    # uuid4 generated token.
+    token = 'a1d895e0-553a-421a-8e22-5ff8ecb48cbf'
+    headers = {
+        'content-type': 'application/json',
+        'Authorization': 'Token {}'.format(token)
+    }
+
+    request, response = sanic_endpoint_test(app, headers=headers)
+
+    assert request.token == token
+
 # ------------------------------------------------------------ #
 #  POST
 # ------------------------------------------------------------ #


### PR DESCRIPTION
I added a token property to the request object which makes it easier to access the 'Authorization' header via request.token

 ``` py
   @property
    def token(self):
        """
        Attempts to return the auth header token.
        :return: token related to request
        """
        auth_header = self.headers.get('Authorization')
        if auth_header is not None:
            return auth_header.split()[1]
        return auth_header
```

The way it's set up is to work with common Authorization headers which normally put some text before the actual token like `Bearer`, `Basic` or `Token`. Regardless of what's in front of the actual token, it returns the token.

I added a test to confirm that it's working as intended.