### PR TITLE
Added features to do Sanic more pluggable (example included)

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -39,13 +39,14 @@ class Request(dict):
     """
     __slots__ = (
         'url', 'headers', 'version', 'method', '_cookies',
-        'query_string', 'body',
+        'query_string', 'body', 'app', 'handler',
         'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
     )
 
-    def __init__(self, url_bytes, headers, version, method):
+    def __init__(self, url_bytes, headers, version, method, app=None):
         # TODO: Content-Encoding detection
         url_parsed = parse_url(url_bytes)
+        self.app = app
         self.url = url_parsed.path.decode('utf-8')
         self.headers = headers
         self.version = version

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -116,19 +116,21 @@ class Sanic:
         else:
             attach_to = args[0]
             return register_middleware
-    
+
     def add_middleware(self, middleware, attach_to="request"):
         """
-        register a middleware and configure to be called before a request of after
-        
+        register a middleware and configure to be called before a
+        request of after
+
         :param middleware: a callable function (coroutine)
         :type middleware: callable
-        
-        :param attach_to: where to attach the middleware: before a request of after
+
+        :param attach_to: where to attach the middleware: before a
+                          request of after
         :type attach_to: str
         """
         assert attach_to in ("request", "response")
-        
+
         if attach_to == 'request':
             self.request_middleware.append(middleware)
         if attach_to == 'response':
@@ -185,10 +187,10 @@ class Sanic:
         :return: Nothing
         """
         try:
-            
+
             # Add view handler
             request.handler = self.router.routes_static.get(request.url)
-            
+
             # -------------------------------------------- #
             # Request Middleware
             # -------------------------------------------- #

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -116,6 +116,23 @@ class Sanic:
         else:
             attach_to = args[0]
             return register_middleware
+    
+    def add_middleware(self, middleware, attach_to="request"):
+        """
+        register a middleware and configure to be called before a request of after
+        
+        :param middleware: a callable function (coroutine)
+        :type middleware: callable
+        
+        :param attach_to: where to attach the middleware: before a request of after
+        :type attach_to: str
+        """
+        assert attach_to in ("request", "response")
+        
+        if attach_to == 'request':
+            self.request_middleware.append(middleware)
+        if attach_to == 'response':
+            self.response_middleware.appendleft(middleware)
 
     # Static Files
     def static(self, uri, file_or_directory, pattern='.+',

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -185,6 +185,10 @@ class Sanic:
         :return: Nothing
         """
         try:
+            
+            # Add view handler
+            request.handler = self.router.routes_static.get(request.url)
+            
             # -------------------------------------------- #
             # Request Middleware
             # -------------------------------------------- #
@@ -291,6 +295,7 @@ class Sanic:
             'request_timeout': self.config.REQUEST_TIMEOUT,
             'request_max_size': self.config.REQUEST_MAX_SIZE,
             'loop': loop
+            # 'app': self
         }
 
         # -------------------------------------------- #

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -294,8 +294,8 @@ class Sanic:
             'error_handler': self.error_handler,
             'request_timeout': self.config.REQUEST_TIMEOUT,
             'request_max_size': self.config.REQUEST_MAX_SIZE,
-            'loop': loop
-            # 'app': self
+            'loop': loop,
+            'app': self
         }
 
         # -------------------------------------------- #

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -227,8 +227,8 @@ def trigger_events(events, loop):
                 loop.run_until_complete(result)
 
 
-def serve(host, port, request_handler, error_handler, app=None, before_start=None,
-          after_start=None, before_stop=None, after_stop=None,
+def serve(host, port, request_handler, error_handler, before_start=None,
+          after_start=None, before_stop=None, after_stop=None, app=None,
           debug=False, request_timeout=60, sock=None,
           request_max_size=None, reuse_port=False, loop=None):
     """

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -29,6 +29,8 @@ class HttpProtocol(asyncio.Protocol):
     __slots__ = (
         # event loop, connection
         'loop', 'transport', 'connections', 'signal',
+        # Environment info
+        'app',
         # request params
         'parser', 'request', 'url', 'headers',
         # request config
@@ -36,9 +38,10 @@ class HttpProtocol(asyncio.Protocol):
         # connection management
         '_total_request_size', '_timeout_handler', '_last_communication_time')
 
-    def __init__(self, *, loop, request_handler, error_handler,
+    def __init__(self, *, loop, request_handler, error_handler, app=None,
                  signal=Signal(), connections={}, request_timeout=60,
                  request_max_size=None):
+        self.app = app
         self.loop = loop
         self.transport = None
         self.request = None
@@ -129,7 +132,8 @@ class HttpProtocol(asyncio.Protocol):
             url_bytes=self.url,
             headers=CIMultiDict(self.headers),
             version=self.parser.get_http_version(),
-            method=self.parser.get_method().decode()
+            method=self.parser.get_method().decode(),
+            app=self.app
         )
 
     def on_body(self, body):
@@ -223,7 +227,7 @@ def trigger_events(events, loop):
                 loop.run_until_complete(result)
 
 
-def serve(host, port, request_handler, error_handler, before_start=None,
+def serve(host, port, request_handler, error_handler, app=None, before_start=None,
           after_start=None, before_stop=None, after_stop=None,
           debug=False, request_timeout=60, sock=None,
           request_max_size=None, reuse_port=False, loop=None):
@@ -256,6 +260,7 @@ def serve(host, port, request_handler, error_handler, before_start=None,
     signal = Signal()
     server = partial(
         HttpProtocol,
+        app=app,
         loop=loop,
         connections=connections,
         signal=signal,


### PR DESCRIPTION
This PR try to add some features that already exists in other frameworks (like aiohttp) and that are useful for the plugin development:
- add te "app" property into each request, with te Sanic instances 
- add the property "handler" in each request, that contains the view handed where the request was originated 
- new method to add a middleware: add_middelware

The features do not affect to the performance (I was tested) and the could be very useful try to grow the framework and create plugins like:

Example of a A cache system
---------------------------

```python

import asyncio
import uvloop

from aiocache import RedisCache, MemcachedCache, SimpleMemoryCache
from aiocache.serializers import JsonSerializer

#
# Decorator
#
class cache(object):
    def __init__(self, expires: int = 3600, unless: bool = False, use_post_data = False):
        self.expires = expires
        self.unless = unless
        self.use_post_data = use_post_data
    
    def __call__(self, f):
        f.cache_enable = True
        f.cache_expires = self.expires
        f.cache_unless = self.unless
        f.cache_user_post_data = self.use_post_data
        
        return f

#
# Middleware
#
async def cache_middleware(request):
    _handler = request.handler
    try:
        if getattr(_handler, "cache_enable", False):
            #
            # Cache is disabled?
            #
            if getattr(_handler, "cache_unless", False) is True:
                return await _handler(request)
        
            cache_backend = request.app.config.cache
        
            #
            # Make key
            #
            key = "{method}#{path}#{post_data}".format(
                method=request.method,
                path=request.url,
                post_data=request.body if getattr(_handler, "cache_user_post_data") else "")
        
            cached_response = await cache_backend.get(key)
            if cached_response:
                return HTTPResponse(**cached_response)
        
            #
            # Generate cache
            #
            original_response = await _handler(request)
        
            data = dict(status=original_response.status,
                        content_type=original_response.content_type,
                        headers=original_response.headers,
                        body=original_response.body)
        
            expires = getattr(_handler, "cache_expires", 300)
        
            await cache_backend.set(key, data, ttl=expires)
        
            return original_response
    except Exception as e:
        return text(str(e))

    # Not cached
    return await _handler(request)


#
# Cache configuration
#
def setup_cache(app: Sanic,
                cache_type: str = "memory",
                loop=None):
    _cache_backend = None
    if cache_type.lower() == "memory":
        _cache_backend = SimpleMemoryCache(serializer=JsonSerializer())
    
    elif cache_type.lower() == "redis":
        _cache_backend = RedisCache(serializer=JsonSerializer(), loop=loop)
    
    elif cache_type.lower() == "memcached":
        _cache_backend = MemcachedCache(serializer=JsonSerializer(), loop=loop)
    
    else:
        raise HTTPResponse("Invalid cache type selected")
    
    app.config.cache = _cache_backend
    app.add_middleware(cache_middleware)

#
# Main
#   
asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())

loop = asyncio.get_event_loop()

app = Sanic()
    
@app.route("/")
@cache()
async def test(request):
    return json({"hello": "world"})


setup_cache(app, loop=loop, cache_type="memory")
# setup_cache(app, loop=loop, cache_type="redis")
    
app.run(host='127.0.0.1',
        port=8000,
        loop=loop)    
```