### PR TITLE
Print original exception in debug mode.

### DIFF
--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -1,5 +1,6 @@
 from asyncio import get_event_loop
 from collections import deque
+from contextlib import suppress
 from functools import partial
 from inspect import isawaitable, stack, getmodulename
 from multiprocessing import Process, Event
@@ -219,11 +220,8 @@ class Sanic:
             # -------------------------------------------- #
             if self.debug:
                 error_body = response.body
-                if isinstance(error_body, bytes):
-                    try:
-                        error_body = error_body.decode()
-                    except:
-                        pass
+                with suppress(Exception):
+                    error_body = error_body.decode()
                 log.debug(error_body)
 
             try:

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -217,6 +217,14 @@ class Sanic:
             # -------------------------------------------- #
             # Response Generation Failed
             # -------------------------------------------- #
+            if self.debug:
+                error_body = response.body
+                if isinstance(error_body, bytes):
+                    try:
+                        error_body = error_body.decode()
+                    except:
+                        pass
+                log.debug(error_body)
 
             try:
                 response = self.error_handler.response(request, e)


### PR DESCRIPTION
Sanic is collecting the information of original exceptions but does not print it on console. Because it is very useful to debug user code, it is better to be printed in debug mode.
