### PR TITLE
Cache request.json even when it's empty.

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -56,7 +56,7 @@ class Request(dict):
 
         # Init but do not inhale
         self.body = None
-        self.parsed_json = ...
+        self.parsed_json = None
         self.parsed_form = None
         self.parsed_files = None
         self.parsed_args = None
@@ -64,7 +64,7 @@ class Request(dict):
 
     @property
     def json(self):
-        if self.parsed_json is ...:
+        if self.parsed_json is None:
             try:
                 self.parsed_json = json_loads(self.body)
             except Exception:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -56,7 +56,7 @@ class Request(dict):
 
         # Init but do not inhale
         self.body = None
-        self.parsed_json = None
+        self.parsed_json = ...
         self.parsed_form = None
         self.parsed_files = None
         self.parsed_args = None
@@ -64,7 +64,7 @@ class Request(dict):
 
     @property
     def json(self):
-        if not self.parsed_json:
+        if self.parsed_json is ...:
             try:
                 self.parsed_json = json_loads(self.body)
             except Exception:


### PR DESCRIPTION
In case of request body is set to `{}`, `[]` <strike>or `null`</strike>, despite it's already processed, `parsed_json` cache won't be used due to its boolean evaluation. This PR resolves that so now it caches whatever it's inside<strike>, and with using `...`(ellipsis), we can cache `null`(`None`) as well</strike>.