### PR TITLE
add support for virtual hosts

### DIFF
--- a/examples/vhosts.py
+++ b/examples/vhosts.py
@@ -1,0 +1,18 @@
+from sanic.response import text
+from sanic import Sanic
+
+# Usage
+# curl -H "Host: example.com" localhost:8000
+# curl -H "Host: sub.example.com" localhost:8000
+
+app = Sanic()
+
+@app.route('/', host="example.com")
+async def hello(request):
+    return text("Answer")
+@app.route('/', host="sub.example.com")
+async def hello(request):
+    return text("42")
+
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", port=8000)

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -51,7 +51,7 @@ class Sanic:
     # -------------------------------------------------------------------- #
 
     # Decorator
-    def route(self, uri, methods=None):
+    def route(self, uri, methods=None, host=None):
         """
         Decorates a function to be registered as a route
         :param uri: path of the URL
@@ -65,12 +65,13 @@ class Sanic:
             uri = '/' + uri
 
         def response(handler):
-            self.router.add(uri=uri, methods=methods, handler=handler)
+            self.router.add(uri=uri, methods=methods, handler=handler,
+                            host=host)
             return handler
 
         return response
 
-    def add_route(self, handler, uri, methods=None):
+    def add_route(self, handler, uri, methods=None, host=None):
         """
         A helper method to register class instance or
         functions as a handler to the application url
@@ -80,11 +81,11 @@ class Sanic:
         :param methods: list or tuple of methods allowed
         :return: function or class instance
         """
-        self.route(uri=uri, methods=methods)(handler)
+        self.route(uri=uri, methods=methods, host=host)(handler)
         return handler
 
-    def remove_route(self, uri, clean_cache=True):
-        self.router.remove(uri, clean_cache)
+    def remove_route(self, uri, clean_cache=True, host=None):
+        self.router.remove(uri, clean_cache, host)
 
     # Decorator
     def exception(self, *exceptions):

--- a/tests/test_vhosts.py
+++ b/tests/test_vhosts.py
@@ -1,0 +1,23 @@
+from sanic import Sanic
+from sanic.response import json, text
+from sanic.utils import sanic_endpoint_test
+
+
+def test_vhosts():
+    app = Sanic('test_text')
+
+    @app.route('/', host="example.com")
+    async def handler(request):
+        return text("You're at example.com!")
+
+    @app.route('/', host="subdomain.example.com")
+    async def handler(request):
+        return text("You're at subdomain.example.com!")
+
+    headers = {"Host": "example.com"}
+    request, response = sanic_endpoint_test(app, headers=headers)
+    assert response.text == "You're at example.com!"
+
+    headers = {"Host": "subdomain.example.com"}
+    request, response = sanic_endpoint_test(app, headers=headers)
+    assert response.text == "You're at subdomain.example.com!"


### PR DESCRIPTION
Addresses issue #277. Includes a test and defaults to the current behavior if no hosts are specified.

Here is an example as well:

```python
from sanic.response import text
from sanic import Sanic

app = Sanic()

@app.route('/', host="example.com")
async def hello(request):
    return text("Answer")
@app.route('/', host="sub.example.com")
async def hello(request):
    return text("42")

if __name__ == '__main__':
    app.run(host="0.0.0.0", port=8000)
```

Then:

```
curl -H "Host: example.com" localhost:8000
Answer
curl -H "Host: sub.example.com" localhost:8000
42
```

Note that if you use the `host` key with a route then you must use it for all of them. This is a result of the implementation and should be fixed, to allow default hosts. However since this doesn't impact current behavior and provides basic support, I would see that as a new separate issue. Testing with `wrk` I saw no noticeable performance impact, even when routing with a host. So, I think this should be merged and we can address allowing defaults with vhosts later.