### PR TITLE
Fix doc “Class based views”.

### DIFF
--- a/docs/class_based_views.md
+++ b/docs/class_based_views.md
@@ -28,7 +28,7 @@ class SimpleView(HTTPMethodView):
   def delete(self, request):
       return text('I am delete method')
 
-app.add_route(SimpleView.as_view(), '/')
+app.add_route(SimpleView(), '/')
 
 ```
 
@@ -40,7 +40,7 @@ class NameView(HTTPMethodView):
   def get(self, request, name):
     return text('Hello {}'.format(name))
 
-app.add_route(NameView.as_view(), '/<name>')
+app.add_route(NameView(), '/<name>')
 
 ```
 
@@ -53,6 +53,6 @@ class ViewWithDecorator(HTTPMethodView):
   def get(self, request, name):
     return text('Hello I have a decorator')
 
-app.add_route(ViewWithDecorator.as_view(), '/url')
+app.add_route(ViewWithDecorator(), '/url')
 
 ```


### PR DESCRIPTION
Hi, I learned Sanic by reading the doc.
At "Class based views", I got this:
```python
Traceback (most recent call last):
  File "class_based_views.py", line 26, in <module>
    app.add_route(SimpleView.as_view(), '/')
AttributeError: type object 'SimpleView' has no attribute 'as_view'
```
Then I check the `HTTPMethodView.__doc__`, I find that we don't need to use `SimpleView.as_view()`, just `SimpleView()` is fine.

So, hope you can approve this pull request.