### PR TITLE
remove default from host in _get method

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -158,7 +158,7 @@ class Router:
                              request.headers.get("Host", ''))
 
     @lru_cache(maxsize=Config.ROUTER_CACHE_SIZE)
-    def _get(self, url, method, host=None):
+    def _get(self, url, method, host):
         """
         Gets a request handler based on the URL of the request, or raises an
         error.  Internal method for caching.


### PR DESCRIPTION
This would error if it were actually  `None` and the default is provided in the `get()` method, so it's never used anyway.