### PR TITLE
add vhosts to blueprints

### DIFF
--- a/examples/vhosts.py
+++ b/examples/vhosts.py
@@ -1,11 +1,15 @@
 from sanic.response import text
 from sanic import Sanic
+from sanic.blueprints import Blueprint
 
 # Usage
 # curl -H "Host: example.com" localhost:8000
 # curl -H "Host: sub.example.com" localhost:8000
+# curl -H "Host: bp.example.com" localhost:8000/question
+# curl -H "Host: bp.example.com" localhost:8000/answer
 
 app = Sanic()
+bp = Blueprint("bp", host="bp.example.com")
 
 @app.route('/', host="example.com")
 async def hello(request):
@@ -13,6 +17,16 @@ async def hello(request):
 @app.route('/', host="sub.example.com")
 async def hello(request):
     return text("42")
+
+@bp.route("/question")
+async def hello(request):
+    return text("What is the meaning of life?")
+
+@bp.route("/answer")
+async def hello(request):
+    return text("42")
+
+app.register_blueprint(bp)
 
 if __name__ == '__main__':
     app.run(host="0.0.0.0", port=8000)

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -87,18 +87,18 @@ class Blueprint:
         for deferred in self.deferred_functions:
             deferred(state)
 
-    def route(self, uri, methods=None):
+    def route(self, uri, methods=None, host=None):
         """
         """
         def decorator(handler):
-            self.record(lambda s: s.add_route(handler, uri, methods))
+            self.record(lambda s: s.add_route(handler, uri, methods, host))
             return handler
         return decorator
 
-    def add_route(self, handler, uri, methods=None):
+    def add_route(self, handler, uri, methods=None, host=None):
         """
         """
-        self.record(lambda s: s.add_route(handler, uri, methods))
+        self.record(lambda s: s.add_route(handler, uri, methods, host))
         return handler
 
     def listener(self, event):

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -18,14 +18,17 @@ class BlueprintSetup:
         #: blueprint.
         self.url_prefix = url_prefix
 
-    def add_route(self, handler, uri, methods):
+    def add_route(self, handler, uri, methods, host=None):
         """
         A helper method to register a handler to the application url routes.
         """
         if self.url_prefix:
             uri = self.url_prefix + uri
 
-        self.app.route(uri=uri, methods=methods)(handler)
+        if host is None:
+            host = self.blueprint.host
+
+        self.app.route(uri=uri, methods=methods, host=host)(handler)
 
     def add_exception(self, handler, *args, **kwargs):
         """
@@ -53,7 +56,7 @@ class BlueprintSetup:
 
 
 class Blueprint:
-    def __init__(self, name, url_prefix=None):
+    def __init__(self, name, url_prefix=None, host=None):
         """
         Creates a new blueprint
         :param name: Unique name of the blueprint
@@ -63,6 +66,7 @@ class Blueprint:
         self.url_prefix = url_prefix
         self.deferred_functions = []
         self.listeners = defaultdict(list)
+        self.host = host
 
     def record(self, func):
         """

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -67,12 +67,21 @@ def test_bp_with_host():
     def handler(request):
         return text('Hello')
 
+    @bp.route('/', host="sub.example.com")
+    def handler(request):
+        return text('Hello subdomain!')
+
     app.blueprint(bp)
     headers = {"Host": "example.com"}
     request, response = sanic_endpoint_test(app, uri='/test1/',
                                             headers=headers)
-
     assert response.text == 'Hello'
+
+    headers = {"Host": "sub.example.com"}
+    request, response = sanic_endpoint_test(app, uri='/test1/',
+                                            headers=headers)
+
+    assert response.text == 'Hello subdomain!'
 
 
 def test_several_bp_with_host():

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -59,6 +59,62 @@ def test_several_bp_with_url_prefix():
     request, response = sanic_endpoint_test(app, uri='/test2/')
     assert response.text == 'Hello2'
 
+def test_bp_with_host():
+    app = Sanic('test_bp_host')
+    bp = Blueprint('test_bp_host', url_prefix='/test1', host="example.com")
+
+    @bp.route('/')
+    def handler(request):
+        return text('Hello')
+
+    app.blueprint(bp)
+    headers = {"Host": "example.com"}
+    request, response = sanic_endpoint_test(app, uri='/test1/',
+                                            headers=headers)
+
+    assert response.text == 'Hello'
+
+
+def test_several_bp_with_host():
+    app = Sanic('test_text')
+    bp = Blueprint('test_text',
+                   url_prefix='/test',
+                   host="example.com")
+    bp2 = Blueprint('test_text2',
+                    url_prefix='/test',
+                    host="sub.example.com")
+
+    @bp.route('/')
+    def handler(request):
+        return text('Hello')
+
+    @bp2.route('/')
+    def handler2(request):
+        return text('Hello2')
+
+    @bp2.route('/other/')
+    def handler2(request):
+        return text('Hello3')
+
+
+    app.blueprint(bp)
+    app.blueprint(bp2)
+
+    assert bp.host == "example.com"
+    headers = {"Host": "example.com"}
+    request, response = sanic_endpoint_test(app, uri='/test/',
+                                            headers=headers)
+    assert response.text == 'Hello'
+
+    assert bp2.host == "sub.example.com"
+    headers = {"Host": "sub.example.com"}
+    request, response = sanic_endpoint_test(app, uri='/test/',
+                                            headers=headers)
+
+    assert response.text == 'Hello2'
+    request, response = sanic_endpoint_test(app, uri='/test/other/',
+                                            headers=headers)
+    assert response.text == 'Hello3'
 
 def test_bp_middleware():
     app = Sanic('test_middleware')


### PR DESCRIPTION
This partially addresses #102, as you can do this after this change:

```python
from sanic.response import text
from sanic import Sanic
from sanic.blueprints import Blueprint

# Usage
# curl -H "Host: bp1.example.com" localhost:8000/question
# curl -H "Host: bp2.example.com" localhost:8000/answer

app = Sanic()
bp = Blueprint("bp", host="bp1.example.com")
bp2 = Blueprint("bp2", host="bp2.example.com")

@bp1.route("/question")
async def hello(request):
    return text("What is the meaning of life?")

@bp2.route("/answer")
async def hello(request):
    return text("42")

app.register_blueprint(bp1)
app.register_blueprint(bp2)

if __name__ == '__main__':
    app.run(host="0.0.0.0", port=8000)
```