### PR TITLE
Signaling support and middleware behaviour

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,0 +1,27 @@
+# Signals
+
+Signals allow you to send notifications to multiple subscribers when the specific event occured.
+Signaling is provided by [Blinker](http://pythonhosted.org/blinker/) library and
+Sanic has few built-in signals:
+
+* `request_started`: Sent when the request processing has started.
+* `request_finished`: Sent when the request processing has finished.
+
+## Examples
+
+```python
+from sanic.signals import request_started
+import my_realtime_stat
+
+app = Sanic(__name__)
+
+@request_started.connect
+def collect_stats(request):
+    my_realtime_stat.incoming_requests.incr(request.url)
+
+
+@request_finished.connect
+def count_errors(response):
+    if response.status != 200:
+        my_realtime_stat.error_responses.incr(response.status)
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ httptools
 ujson
 uvloop
 aiofiles
+multidict
+blinker

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -13,6 +13,7 @@ from .log import log
 from .response import HTTPResponse
 from .router import Router
 from .server import serve, HttpProtocol
+from .signals import request_started, request_finished
 from .static import register as static_register
 from .exceptions import ServerError
 from socket import socket, SOL_SOCKET, SO_REUSEADDR
@@ -176,6 +177,8 @@ class Sanic:
         :return: Nothing
         """
         try:
+            request_started.send(request)
+
             # -------------------------------------------- #
             # Request Middleware
             # -------------------------------------------- #
@@ -239,6 +242,7 @@ class Sanic:
                     response = HTTPResponse(
                         "An error occurred while handling an error")
 
+        request_finished.send(response)
         response_callback(response)
 
     # -------------------------------------------------------------------- #

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -179,6 +179,13 @@ class Sanic:
         try:
             request_started.send(request)
 
+            # Fetch handler from router
+            handler, args, kwargs = self.router.get(request)
+            if handler is None:
+                raise ServerError(
+                    ("'None' was returned while requesting a "
+                     "handler from the router"))
+
             # -------------------------------------------- #
             # Request Middleware
             # -------------------------------------------- #
@@ -196,17 +203,9 @@ class Sanic:
             # No middleware results
             if not response:
                 # -------------------------------------------- #
-                # Execute Handler
+                # Execute Response Handler
                 # -------------------------------------------- #
 
-                # Fetch handler from router
-                handler, args, kwargs = self.router.get(request)
-                if handler is None:
-                    raise ServerError(
-                        ("'None' was returned while requesting a "
-                         "handler from the router"))
-
-                # Run response handler
                 response = handler(request, *args, **kwargs)
                 if isawaitable(response):
                     response = await response

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -1,0 +1,10 @@
+from blinker import Namespace
+
+__all__ = ('request_started', 'request_finished')
+
+_signals = Namespace()
+signal = _signals.signal
+
+
+request_started = signal('request-started')
+request_finished = signal('request-finished')

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -1,5 +1,6 @@
 import aiohttp
 from sanic.log import log
+from sanic.signals import request_started
 
 HOST = '127.0.0.1'
 PORT = 42101
@@ -24,7 +25,7 @@ def sanic_endpoint_test(app, method='get', uri='/', gather_request=True,
     if gather_request:
         def _collect_request(request):
             results.append(request)
-        app.request_middleware.appendleft(_collect_request)
+        request_started.connect(_collect_request)
 
     async def _collect_response(sanic, loop):
         try:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -71,6 +71,25 @@ def test_middleware_override_request():
     assert response.text == 'OK'
 
 
+def test_middleware_override_scope():
+    app = Sanic('test_middleware_override_scope')
+
+    @app.middleware
+    async def validate_request(request):
+        if not request.headers.get('X-REQUIRED-HEADER'):
+            return text('X-REQUIRED-HEADER is missing.', status=412)
+
+    @app.route('/')
+    async def handler(request):
+        return text('OK')
+
+    response = sanic_endpoint_test(app, uri='/', gather_request=False)
+    assert response.status == 412
+
+    response = sanic_endpoint_test(app, uri='/nothing/', gather_request=False)
+    assert response.status == 404
+
+
 def test_middleware_override_response():
     app = Sanic('test_middleware_override_response')
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ python =
 
 deps =
     aiohttp
+    blinker
     pytest
     beautifulsoup4
 


### PR DESCRIPTION
Summary:
* Added signaling support with two built-in signals: `request_started`, `request_finished`.
* Fixed request middlewares to be executed only when there's handler so 404 can properly work.
* `sanic_endpoint_test()` uses signal to gather request rather than using middleware.

---

First catch: 
Request middlewares are applied to all requests even if there's no registered routes.
For example, if I write a request-validating middleware, the application will respond 400(or whatever) against any bad requests. And... the 404 will disappear. That was completely unexpected behaviour to me. (Test added: https://github.com/channelcat/sanic/commit/d603bcc3d05e630acd179367b05b35627e0018ef#diff-da5a345e8216a8e47d28218a4f5b9b0f)

To fix the first catch:
Before processing request, the application should determine whether the request is able to be handled or not- looking up the handler from the router. If there's no handler, abort the processing and we can respond with 404.

Trouble:
`sanic_endpoint_test()` was using middleware to collect request.
In case of the situation that middlewares are not executed(testing with 404 paths), tester function can't gather the request so a lot of tests will broken.

New motivation from trouble:
We need to have *pre*-process-handling layer.
I thought we can have two choices here: introducing 'before_before_request' middleware so it can come before the 'before_request' middleware(`@middleware('request')`). Or, having signaling system.
Considering the current need-recording the request- and our current middleware's simplicity, I carefully decided that having signaling system would be better than extend/expand/ing the middlewares.