### PR TITLE
Add SSL context to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ if __name__ == "__main__":
 ## Installation
  * `python -m pip install sanic`
 
+## Use SSL
+ * Optionally pass in an SSLContext:
+```
+import ssl
+certificate = "/path/to/certificate"
+keyfile = "/path/to/keyfile"
+context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+context.load_cert_chain(certificate, keyfile=keyfile)
+
+app.run(host="0.0.0.0", port=8443, ssl=context)
+```
+
 ## Documentation
  * [Getting started](docs/getting_started.md)
  * [Request Data](docs/request_data.md)

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -245,9 +245,9 @@ class Sanic:
     # -------------------------------------------------------------------- #
 
     def run(self, host="127.0.0.1", port=8000, debug=False, before_start=None,
-            after_start=None, before_stop=None, after_stop=None, sock=None,
-            workers=1, loop=None, protocol=HttpProtocol, backlog=100,
-            stop_event=None):
+            after_start=None, before_stop=None, after_stop=None, ssl=None,
+            sock=None, workers=1, loop=None, protocol=HttpProtocol,
+            backlog=100, stop_event=None):
         """
         Runs the HTTP Server and listens until keyboard interrupt or term
         signal. On termination, drains connections before closing.
@@ -262,6 +262,7 @@ class Sanic:
         received before it is respected
         :param after_stop: Functions to be executed when all requests are
         complete
+        :param ssl: SSLContext for SSL encryption of worker(s)
         :param sock: Socket for the server to accept connections from
         :param workers: Number of processes
         received before it is respected
@@ -278,6 +279,7 @@ class Sanic:
             'host': host,
             'port': port,
             'sock': sock,
+            'ssl': ssl,
             'debug': debug,
             'request_handler': self.handle_request,
             'error_handler': self.error_handler,
@@ -315,7 +317,11 @@ class Sanic:
         log.debug(self.config.LOGO)
 
         # Serve
-        log.info('Goin\' Fast @ http://{}:{}'.format(host, port))
+        if ssl is None:
+            proto = "http"
+        else:
+            proto = "https"
+        log.info('Goin\' Fast @ {}://{}:{}'.format(proto, host, port))
 
         try:
             if workers == 1:

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -225,7 +225,7 @@ def trigger_events(events, loop):
 
 def serve(host, port, request_handler, error_handler, before_start=None,
           after_start=None, before_stop=None, after_stop=None, debug=False,
-          request_timeout=60, sock=None, request_max_size=None,
+          request_timeout=60, ssl=None, sock=None, request_max_size=None,
           reuse_port=False, loop=None, protocol=HttpProtocol, backlog=100):
     """
     Starts asynchronous HTTP Server on an individual process.
@@ -243,6 +243,7 @@ def serve(host, port, request_handler, error_handler, before_start=None,
     received after it is respected. Takes single argumenet `loop`
     :param debug: Enables debug output (slows server)
     :param request_timeout: time in seconds
+    :param ssl: SSLContext
     :param sock: Socket for the server to accept connections from
     :param request_max_size: size in bytes, `None` for no limit
     :param reuse_port: `True` for multiple workers
@@ -275,6 +276,7 @@ def serve(host, port, request_handler, error_handler, before_start=None,
         server,
         host,
         port,
+        ssl=ssl,
         reuse_port=reuse_port,
         sock=sock,
         backlog=backlog


### PR DESCRIPTION
Currently the Sanic server appears to only support HTTP. This PR will allow the setup of a SSL connection to the server, to upgrade sockets to HTTPS. The motivation behind this PR is to maintain the sanic/uvloop speed gains, without having to rely on other HTTP servers (Apache, Nginx) to provide a reverse proxy, essentially slowing down the connection.

Added an example in the README that details how to create the SSLContext, which can then be passed in. This works for single and multiple workers.

Add ssl variable passthrough to following:
-- sanic.run
-- server.serve
Add ssl variable to loop.create_server to enable built-in async context socket wrapper
Update documentation
Tested with worker = 1, and worker = 2.
Unit tests are passing

Signed-off-by: Matt Daue <mattdaue@gmail.com>