### PR TITLE
Moved Remote-Addr header to request.ip

### DIFF
--- a/docs/request_data.md
+++ b/docs/request_data.md
@@ -9,6 +9,7 @@ The following request variables are accessible as properties:
 `request.args` (dict) - Query String variables.  Use getlist to get multiple of the same name  
 `request.form` (dict) - Posted form variables.  Use getlist to get multiple of the same name  
 `request.body` (bytes) - Posted raw body.  To get the raw data, regardless of content type  
+`request.ip` (str) - IP address of the requester
 
 See request.py for more information
 

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -41,18 +41,19 @@ class Request(dict):
     Properties of an HTTP request such as URL, headers, etc.
     """
     __slots__ = (
-        'url', 'headers', 'version', 'method', '_cookies',
+        'url', 'headers', 'version', 'method', '_cookies', 'transport',
         'query_string', 'body',
         'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
     )
 
-    def __init__(self, url_bytes, headers, version, method):
+    def __init__(self, url_bytes, headers, version, method, transport):
         # TODO: Content-Encoding detection
         url_parsed = parse_url(url_bytes)
         self.url = url_parsed.path.decode('utf-8')
         self.headers = headers
         self.version = version
         self.method = method
+        self.transport = transport
         self.query_string = None
         if url_parsed.query:
             self.query_string = url_parsed.query.decode('utf-8')
@@ -138,6 +139,10 @@ class Request(dict):
             else:
                 self._cookies = {}
         return self._cookies
+
+    @property
+    def ip(self):
+        return self.transport.get_extra_info('peername')
 
 
 File = namedtuple('File', ['type', 'body', 'name'])

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -121,15 +121,12 @@ class HttpProtocol(asyncio.Protocol):
         self.headers.append((name.decode(), value.decode('utf-8')))
 
     def on_headers_complete(self):
-        remote_addr = self.transport.get_extra_info('peername')
-        if remote_addr:
-            self.headers.append(('Remote-Addr', '%s:%s' % remote_addr))
-
         self.request = Request(
             url_bytes=self.url,
             headers=CIMultiDict(self.headers),
             version=self.parser.get_http_version(),
-            method=self.parser.get_method().decode()
+            method=self.parser.get_method().decode(),
+            transport=self.transport
         )
 
     def on_body(self, body):


### PR DESCRIPTION
Sadly, pulling IP is costly.  Moving it to a property that pulls on-demand should bump Sanic's performance back up by about 10%.  Also Ubuntu stole my commit credz :(.