### PR TITLE
Always log if there's an exception occurred.

### DIFF
--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -173,6 +173,7 @@ class Handler:
         try:
             response = handler(request=request, exception=exception)
         except:
+            log.error(format_exc())
             if self.sanic.debug:
                 response_message = (
                     'Exception raised in exception handler "{}" '
@@ -185,6 +186,7 @@ class Handler:
         return response
 
     def default(self, request, exception):
+        log.error(format_exc())
         if issubclass(type(exception), SanicException):
             return text(
                 'Error: {}'.format(exception),


### PR DESCRIPTION
Hi,

I'm trying to run sanic in one of my server. My problem is that when there's an exception, I cannot see what happened because there's no log to see. The solution to this is to enable debug mode, the problem with that is the user can see the exception logs as well.

I'm not sure this is the best approach but I propose we always log the exception even though we are not running in debug mode.
