### PR TITLE
remove logger from run

### DIFF
--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -243,7 +243,7 @@ class Sanic:
     def run(self, host="127.0.0.1", port=8000, debug=False, before_start=None,
             after_start=None, before_stop=None, after_stop=None, sock=None,
             workers=1, loop=None, protocol=HttpProtocol, backlog=100,
-            stop_event=None, logger=None):
+            stop_event=None):
         """
         Runs the HTTP Server and listens until keyboard interrupt or term
         signal. On termination, drains connections before closing.


### PR DESCRIPTION
I forgot to remove this from `run()` in https://github.com/channelcat/sanic/pull/308 :(

It's no longer necessary.