### PR TITLE
For function decorators, ['GET'] is the default methods

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -87,7 +87,7 @@ class Blueprint:
         for deferred in self.deferred_functions:
             deferred(state)
 
-    def route(self, uri, methods=None, host=None):
+    def route(self, uri, methods=frozenset({'GET'}), host=None):
         """
         """
         def decorator(handler):

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -46,7 +46,7 @@ class Sanic:
     # -------------------------------------------------------------------- #
 
     # Decorator
-    def route(self, uri, methods=None, host=None):
+    def route(self, uri, methods=frozenset({'GET'}), host=None):
         """
         Decorates a function to be registered as a route
         :param uri: path of the URL

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -497,7 +497,7 @@ def test_overload_routes():
 def test_unmergeable_overload_routes():
     app = Sanic('test_dynamic_route')
 
-    @app.route('/overload_whole')
+    @app.route('/overload_whole', methods=None)
     async def handler1(request):
         return text('OK1')
 


### PR DESCRIPTION
Issue from here: https://github.com/channelcat/sanic/pull/311#issuecomment-273688296

- Because the decorators are designed to be used with functions, it will work.
- It will break backward compatibility. a little.
   - They can be fixed by adding explicit parameters
   - Or just `methods=None` to reuse original behavior.
