### PR TITLE
Fixes doc link extensions from .html to .md

### DIFF
--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -159,6 +159,6 @@ app.blueprint(blueprint_v2)
 app.run(host='0.0.0.0', port=8000, debug=True)
 ```
 
-**Previous:** [Exceptions](exceptions.html)
+**Previous:** [Exceptions](exceptions.md)
 
-**Next:** [Class-based views](class_based_views.html)
+**Next:** [Class-based views](class_based_views.md)

--- a/docs/class_based_views.md
+++ b/docs/class_based_views.md
@@ -77,6 +77,6 @@ class ViewWithDecorator(HTTPMethodView):
 app.add_route(ViewWithDecorator.as_view(), '/url')
 ```
 
-**Previous:** [Blueprints](blueprints.html)
+**Previous:** [Blueprints](blueprints.md)
 
-**Next:** [Cookies](cookies.html)
+**Next:** [Cookies](cookies.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,4 +32,4 @@ Sanic without significant gains in usability, security, or features may not be
 merged. Please don't let this intimidate you! If you have any concerns about an
 idea, open an issue for discussion and help.
 
-**Previous:** [Sanic extensions](extensions.html)
+**Previous:** [Sanic extensions](extensions.md)

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -47,6 +47,6 @@ parameters available:
 - `httponly` (boolean): Specifies whether the cookie cannot be read by
                         Javascript.
 
-**Previous:** [Class-based views](class_based_views.html)
+**Previous:** [Class-based views](class_based_views.md)
 
-**Next:** [Custom protocols](custom_protocol.html)
+**Next:** [Custom protocols](custom_protocol.md)

--- a/docs/custom_protocol.md
+++ b/docs/custom_protocol.md
@@ -5,7 +5,7 @@
 You can change the behavior of Sanic's protocol by specifying a custom
 protocol, which should be a subclass
 of
-[asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.html#protocol-classes).
+[asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.md#protocol-classes).
 This protocol can then be passed as the keyword argument `protocol` to the `sanic.run` method.
 
 The constructor of the custom protocol class receives the following keyword
@@ -71,6 +71,6 @@ async def response(request):
 app.run(host='0.0.0.0', port=8000, protocol=CustomHttpProtocol)
 ```
 
-**Previous:** [Cookies](cookies.html)
+**Previous:** [Cookies](cookies.md)
 
-**Next:** [Testing](testing.html)
+**Next:** [Testing](testing.md)

--- a/docs/custom_protocol.md
+++ b/docs/custom_protocol.md
@@ -5,7 +5,7 @@
 You can change the behavior of Sanic's protocol by specifying a custom
 protocol, which should be a subclass
 of
-[asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.md#protocol-classes).
+[asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.html#protocol-classes).
 This protocol can then be passed as the keyword argument `protocol` to the `sanic.run` method.
 
 The constructor of the custom protocol class receives the following keyword

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -23,7 +23,7 @@ keyword arguments:
                              specified, Sanic creates its own event loop.
 - `protocol` *(default `HttpProtocol`)*: Subclass
   of
-  [asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.md#protocol-classes).
+  [asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.html#protocol-classes).
 
 ## Workers
 

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -23,7 +23,7 @@ keyword arguments:
                              specified, Sanic creates its own event loop.
 - `protocol` *(default `HttpProtocol`)*: Subclass
   of
-  [asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.html#protocol-classes).
+  [asyncio.protocol](https://docs.python.org/3/library/asyncio-protocol.md#protocol-classes).
 
 ## Workers
 
@@ -54,6 +54,6 @@ if __name__ == '__main__':
     app.run(host='0.0.0.0', port=1337, workers=4)
 ```
 
-**Previous:** [Request Data](request_data.html)
+**Previous:** [Request Data](request_data.md)
 
-**Next:** [Static Files](static_files.html)
+**Next:** [Static Files](static_files.md)

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -44,6 +44,6 @@ Some of the most useful exceptions are presented below:
 
 See the `sanic.exceptions` module for the full list of exceptions to throw.
 
-**Previous:** [Middleware](middleware.html)
+**Previous:** [Middleware](middleware.md)
 
-**Next:** [Blueprints](blueprints.html)
+**Next:** [Blueprints](blueprints.md)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -6,6 +6,6 @@ A list of Sanic extensions created by the community.
   Allows using redis, memcache or an in memory store.
 - [CORS](https://github.com/ashleysommer/sanic-cors): A port of flask-cors.
 
-**Previous:** [Testing](testing.html)
+**Previous:** [Testing](testing.md)
 
-**Next:** [Contributing](contributing.html)
+**Next:** [Contributing](contributing.md)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -26,4 +26,4 @@ syntax, so earlier versions of python won't work.
 
 You now have a working Sanic server!
 
-**Next:** [Routing](routing.html)
+**Next:** [Routing](routing.md)

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -65,6 +65,6 @@ async def halt_response(request, response):
 	return text('I halted the response')
 ```
 
-**Previous:** [Static Files](static_files.html)
+**Previous:** [Static Files](static_files.md)
 
-**Next:** [Exceptions](exceptions.html)
+**Next:** [Exceptions](exceptions.md)

--- a/docs/request_data.md
+++ b/docs/request_data.md
@@ -90,6 +90,6 @@ args.get('titles') # => 'Post 1'
 args.getlist('titles') # => ['Post 1', 'Post 2']
 ```
 
-**Previous:** [Routing](routing.html)
+**Previous:** [Routing](routing.md)
 
-**Next:** [Deploying](deploying.html)
+**Next:** [Deploying](deploying.md)

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -106,6 +106,6 @@ app.add_route(handler2, '/folder/<name>')
 app.add_route(person_handler2, '/person/<name:[A-z]>', methods=['GET'])
 ```
 
-**Previous:** [Getting Started](getting_started.html)
+**Previous:** [Getting Started](getting_started.md)
 
-**Next:** [Request Data](request_data.html)
+**Next:** [Request Data](request_data.md)

--- a/docs/static_files.md
+++ b/docs/static_files.md
@@ -18,6 +18,6 @@ app.static('/the_best.png', '/home/ubuntu/test.png')
 app.run(host="0.0.0.0", port=8000)
 ```
 
-**Previous:** [Deploying](deploying.html)
+**Previous:** [Deploying](deploying.md)
 
-**Next:** [Middleware](middleware.html)
+**Next:** [Middleware](middleware.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,6 +50,6 @@ def test_endpoint_challenge():
     assert response.text == request_data['challenge']
 ```
 
-**Previous:** [Custom protocols](custom_protocol.html)
+**Previous:** [Custom protocols](custom_protocol.md)
 
-**Next:** [Sanic extensions](extensions.html)
+**Next:** [Sanic extensions](extensions.md)


### PR DESCRIPTION
Whoops! Totally missed that all the links pointed to `.html` files
instead of `.md` files

@kdelwat 