### PR TITLE
allowed passing arguments to json response encoder

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -142,14 +142,15 @@ class HTTPResponse:
         return self._cookies
 
 
-def json(body, status=200, headers=None):
+def json(body, status=200, headers=None, **kwargs):
     """
     Returns response object with body in json format.
     :param body: Response data to be serialized.
     :param status: Response code.
     :param headers: Custom Headers.
+    :param \**kwargs: Remaining arguments that are passed to the json encoder.
     """
-    return HTTPResponse(json_dumps(body), headers=headers, status=status,
+    return HTTPResponse(json_dumps(body, **kwargs), headers=headers, status=status,
                         content_type="application/json")
 
 

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -150,8 +150,8 @@ def json(body, status=200, headers=None, **kwargs):
     :param headers: Custom Headers.
     :param \**kwargs: Remaining arguments that are passed to the json encoder.
     """
-    return HTTPResponse(json_dumps(body, **kwargs), headers=headers, status=status,
-                        content_type="application/json")
+    return HTTPResponse(json_dumps(body, **kwargs), headers=headers,
+                        status=status, content_type="application/json")
 
 
 def text(body, status=200, headers=None):


### PR DESCRIPTION
Arguments include ensure_ascii, double_precision, indent, etc.

See:
https://pypi.python.org/pypi/ujson