### PR TITLE
set loop to None if using multiple workers

### DIFF
--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -390,6 +390,11 @@ class Sanic:
         """
         server_settings['reuse_port'] = True
 
+        if server_settings['loop'] is not None:
+            log.warn("Passing the loop is not supported with multiple"
+                     " workers. The loop paramater has been set to None.")
+            server_settings['loop'] = None
+
         # Create a stop event to be triggered by a signal
         if stop_event is None:
             stop_event = Event()


### PR DESCRIPTION
Idea from https://github.com/channelcat/sanic/issues/305. Not sure if we should log a warning or an error, or possibly even raise an exception. I think logging is better than raising an error, since the program might work correctly without passing the loop.