### PR TITLE
`serve` closes the loop only when it created its own loop.

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -290,8 +290,10 @@ def serve(host, port, request_handler, error_handler, before_start=None,
     :param protocol: Subclass of asyncio protocol class
     :return: Nothing
     """
-    loop = loop or async_loop.new_event_loop()
-    asyncio.set_event_loop(loop)
+    create_new_loop = loop is None
+    if create_new_loop:
+        loop = async_loop.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     if debug:
         loop.set_debug(debug)
@@ -360,4 +362,5 @@ def serve(host, port, request_handler, error_handler, before_start=None,
 
         trigger_events(after_stop, loop)
 
-        loop.close()
+        if create_new_loop:
+            loop.close()

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -5,6 +5,13 @@ HOST = '127.0.0.1'
 PORT = 42101
 
 
+try:
+    import uvloop as async_loop
+except ImportError:
+    import asyncio as async_loop
+endpoint_test_loop = async_loop.new_event_loop()
+
+
 async def local_request(method, uri, cookies=None, *args, **kwargs):
     url = 'http://{host}:{port}{uri}'.format(host=HOST, port=PORT, uri=uri)
     log.info(url)
@@ -16,7 +23,7 @@ async def local_request(method, uri, cookies=None, *args, **kwargs):
 
 
 def sanic_endpoint_test(app, method='get', uri='/', gather_request=True,
-                        loop=None, debug=False, server_kwargs={},
+                        loop=endpoint_test_loop, debug=False, server_kwargs={},
                         *request_args, **request_kwargs):
     results = []
     exceptions = []


### PR DESCRIPTION
`serve` closes the loop only when it created its own loop.

When you were running multiple applications using asyncio, sanic must be closed as the latest order because it closes the loop.

The patch limits the behavior only when sanic created its own loop by argument `loop=None`.
And `sanic_endpoint_test` now uses shared event loop by default.