### PR TITLE
Use ``isinstance(`` instead of ``issubclass(type(``

### DIFF
--- a/examples/exception_monitoring.py
+++ b/examples/exception_monitoring.py
@@ -23,7 +23,7 @@ class CustomHandler(Handler):
         # and can do anything with it (log, send to external service, etc)
 
         # Some exceptions are trivial and built into Sanic (404s, etc)
-        if not issubclass(type(exception), SanicException):
+        if not isinstance(exception, SanicException):
             print(exception)
 
         # Then, we must finish handling the exception by returning

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -188,7 +188,7 @@ class Handler:
 
     def default(self, request, exception):
         log.error(format_exc())
-        if issubclass(type(exception), SanicException):
+        if isinstance(exception, SanicException):
             return text(
                 'Error: {}'.format(exception),
                 status=getattr(exception, 'status_code', 500))

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -51,7 +51,7 @@ def test_middleware_response():
     assert response.text == 'OK'
     assert type(results[0]) is Request
     assert type(results[1]) is Request
-    assert issubclass(type(results[2]), HTTPResponse)
+    assert isinstance(results[2], HTTPResponse)
 
 
 def test_middleware_override_request():

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -152,7 +152,7 @@ def test_with_middleware_response():
     assert response.text == 'I am get method'
     assert type(results[0]) is Request
     assert type(results[1]) is Request
-    assert issubclass(type(results[2]), HTTPResponse)
+    assert isinstance(results[2], HTTPResponse)
 
 
 def test_with_custom_class_methods():


### PR DESCRIPTION
When we already have an `instance` it's less typing and faster to
use `isinstance`.