### PR TITLE
Fix docs/config.md: the MYAPP_SETTINGS is not exported

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -54,7 +54,7 @@ app.config.from_envvar('MYAPP_SETTINGS')
 Then you can run your application with the `MYAPP_SETTINGS` environment variable set:
 
 ```
-$ MYAPP_SETTINGS=/path/to/config_file; python3 myapp.py
+$ MYAPP_SETTINGS=/path/to/config_file python3 myapp.py
 INFO: Goin' Fast @ http://0.0.0.0:8000
 ```
 


### PR DESCRIPTION
If we don"t `export` the variable, it's not available in subcommand:

MYAPP_SETTINGS=/path/to/config_file; python3 -c "import os; os.environ['MYAPP_SETTINGS']"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.5/os.py", line 725, in __getitem__
    raise KeyError(key) from None
KeyError: 'MYAPP_SETTINGS'

The ';' is the culprit here.