### PR TITLE
Add `url_for` method for simple routes, blueprints, HTTPMethodView

### DIFF
--- a/docs/sanic/blueprints.md
+++ b/docs/sanic/blueprints.md
@@ -158,3 +158,22 @@ app.blueprint(blueprint_v2)
 
 app.run(host='0.0.0.0', port=8000, debug=True)
 ```
+
+## URL Building with `url_for`
+
+If you wish to generate a URL for a route inside of a blueprint, remember that the endpoint name
+takes the format `<blueprint_name>.<handler_name>`. For example:
+
+```
+@blueprint_v1.route('/')
+async def root(request):
+    url = app.url_for('v1.post_handler', post_id=5)
+    return redirect(url)
+
+
+@blueprint_v1.route('/post/<post_id>')
+async def post_handler(request, post_id):
+    return text('Post {} in Blueprint V1'.format(post_id))
+```
+
+

--- a/docs/sanic/class_based_views.md
+++ b/docs/sanic/class_based_views.md
@@ -67,7 +67,7 @@ app.add_route(NameView.as_view(), '/<name>')
 If you want to add any decorators to the class, you can set the `decorators`
 class variable. These will be applied to the class when `as_view` is called.
 
-```
+```python
 class ViewWithDecorator(HTTPMethodView):
   decorators = [some_decorator_here]
 
@@ -76,6 +76,27 @@ class ViewWithDecorator(HTTPMethodView):
 
 app.add_route(ViewWithDecorator.as_view(), '/url')
 ```
+
+#### URL Building
+
+If you wish to build a URL for an HTTPMethodView, remember that the class name will be the endpoint
+that you will pass into `url_for`. For example:
+
+```python
+@app.route('/')
+def index(request):
+    url = app.url_for('SpecialClassView')
+    return redirect(url)
+
+
+class SpecialClassView(HTTPMethodView):
+    def get(self, request):
+        return text('Hello from the Special Class View!')
+
+
+app.add_route(SpecialClassView.as_view(), '/special_class_view')
+```
+
 
 ## Using CompositionView
 
@@ -106,3 +127,5 @@ view.add(['POST', 'PUT'], lambda request: text('I am a post/put method'))
 # Use the new view to handle requests to the base URL
 app.add_route(view, '/')
 ```
+
+Note: currently you cannot build a URL for a CompositionView using `url_for`. 

--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -120,11 +120,11 @@ app.add_route(handler2, '/folder/<name>')
 app.add_route(person_handler2, '/person/<name:[A-z]>', methods=['GET'])
 ```
 
-## URL building with `url_for`.
+## URL building with `url_for`
 
 Sanic provides a `url_for` method, to generate URLs based on the handler method name. This is useful if you want to avoid hardcoding url paths into your app; instead, you can just reference the handler name. For example:
 
-```
+```python
 @app.route('/')
 async def index(request):
     # generate a URL for the endpoint `post_handler`
@@ -141,7 +141,7 @@ async def post_handler(request, post_id):
 Other things to keep in mind when using `url_for`:
 
 - Keyword arguments passed to `url_for` that are not request parameters will be included in the URL's query string. For example:
-```
+```python
 url = app.url_for('post_handler', post_id=5, arg_one='one', arg_two='two')
 # /posts/5?arg_one=one&arg_two=two
 ```

--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -119,3 +119,35 @@ app.add_route(handler1, '/test')
 app.add_route(handler2, '/folder/<name>')
 app.add_route(person_handler2, '/person/<name:[A-z]>', methods=['GET'])
 ```
+
+## URL building with `url_for`.
+
+Sanic provides a `url_for` method, to generate URLs based on the handler method name. This is useful if you want to avoid hardcoding url paths into your app; instead, you can just reference the handler name. For example:
+
+```
+@app.route('/')
+async def index(request):
+    # generate a URL for the endpoint `post_handler`
+    url = app.url_for('post_handler', post_id=5)
+    # the URL is `/posts/5`, redirect to it
+    return redirect(url)
+
+
+@app.route('/posts/<post_id>')
+async def post_handler(request, post_id):
+    return text('Post - {}'.format(post_id))
+```
+
+Other things to keep in mind when using `url_for`:
+
+- Keyword arguments passed to `url_for` that are not request parameters will be included in the URL's query string. For example:
+```
+url = app.url_for('post_handler', post_id=5, arg_one='one', arg_two='two')
+# /posts/5?arg_one=one&arg_two=two
+```
+- All valid parameters must be passed to `url_for` to build a URL. If a parameter is not supplied, or if a parameter does not match the specified type, a `URLBuildError` will be thrown.
+
+
+
+
+

--- a/docs/sanic/static_files.md
+++ b/docs/sanic/static_files.md
@@ -17,3 +17,5 @@ app.static('/the_best.png', '/home/ubuntu/test.png')
 
 app.run(host="0.0.0.0", port=8000)
 ```
+
+Note: currently you cannot build a URL for a static file using `url_for`. 

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -35,6 +35,9 @@ class Blueprint:
 
         # Routes
         for future in self.routes:
+            # attach the blueprint name to the handler so that it can be
+            # prefixed properly in the router
+            future.handler.__blueprintname__ = self.name
             # Prepend the blueprint URI prefix if available
             uri = url_prefix + future.uri if url_prefix else future.uri
             app.route(

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -120,6 +120,10 @@ class ServerError(SanicException):
     status_code = 500
 
 
+class URLBuildError(SanicException):
+    status_code = 500
+
+
 class FileNotFound(NotFound):
     status_code = 404
 

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -196,7 +196,7 @@ class Router:
                 handler_name = '{}.{}'.format(
                     handler.__blueprintname__, handler.__name__)
             else:
-                handler_name = handler.__name__
+                handler_name = getattr(handler, '__name__', None)
 
             route = Route(
                 handler=handler, methods=methods, pattern=pattern,
@@ -245,6 +245,9 @@ class Router:
         :param view_name: string of view name to search by
         :return: tuple containing (uri, Route)
         """
+        if not view_name:
+            return (None, None)
+
         for uri, route in self.routes_all.items():
             if route.name == view_name:
                 return uri, route

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -445,17 +445,17 @@ class Sanic:
         Helper function used by `run` and `create_server`.
         """
 
-        self.error_handler.debug = debug
-        self.debug = debug
-        self.loop = loop = get_event_loop()
-
         if loop is not None:
-            if self.debug:
+            if debug:
                 warnings.simplefilter('default')
             warnings.warn("Passing a loop will be deprecated in version"
                           " 0.4.0 https://github.com/channelcat/sanic/"
                           "pull/335 has more information.",
                           DeprecationWarning)
+
+        self.error_handler.debug = debug
+        self.debug = debug
+        self.loop = loop = get_event_loop()
 
         server_settings = {
             'protocol': protocol,

--- a/sanic/views.py
+++ b/sanic/views.py
@@ -64,6 +64,7 @@ class HTTPMethodView:
         view.view_class = cls
         view.__doc__ = cls.__doc__
         view.__module__ = cls.__module__
+        view.__name__ = cls.__name__
         return view
 
 

--- a/tests/test_url_building.py
+++ b/tests/test_url_building.py
@@ -3,7 +3,7 @@ from urllib.parse import urlsplit, parse_qsl
 
 from sanic import Sanic
 from sanic.response import text
-from sanic.views import HTTPMethodView, CompositionView
+from sanic.views import HTTPMethodView
 from sanic.blueprints import Blueprint
 from sanic.utils import sanic_endpoint_test
 from sanic.exceptions import URLBuildError

--- a/tests/test_url_building.py
+++ b/tests/test_url_building.py
@@ -1,0 +1,261 @@
+import pytest as pytest
+from urllib.parse import urlsplit, parse_qsl
+
+from sanic import Sanic
+from sanic.response import text
+from sanic.views import HTTPMethodView, CompositionView
+from sanic.blueprints import Blueprint
+from sanic.utils import sanic_endpoint_test
+from sanic.exceptions import URLBuildError
+
+import string
+
+
+def _generate_handlers_from_names(app, l):
+    for name in l:
+        # this is the easiest way to generate functions with dynamic names
+        exec('@app.route(name)\ndef {}(request):\n\treturn text("{}")'.format(
+            name, name))
+
+
+@pytest.fixture
+def simple_app():
+    app = Sanic('simple_app')
+    handler_names = list(string.ascii_letters)
+
+    _generate_handlers_from_names(app, handler_names)
+
+    return app
+
+
+def test_simple_url_for_getting(simple_app):
+    for letter in string.ascii_letters:
+        url = simple_app.url_for(letter)
+
+        assert url == '/{}'.format(letter)
+        request, response = sanic_endpoint_test(
+            simple_app, uri=url)
+        assert response.status == 200
+        assert response.text == letter
+
+
+def test_fails_if_endpoint_not_found():
+    app = Sanic('fail_url_build')
+
+    @app.route('/fail')
+    def fail():
+        return text('this should fail')
+
+    with pytest.raises(URLBuildError) as e:
+        app.url_for('passes')
+
+    assert str(e.value) == 'Endpoint with name `passes` was not found'
+
+
+def test_fails_url_build_if_param_not_passed():
+    url = '/'
+
+    for letter in string.ascii_letters:
+        url += '<{}>/'.format(letter)
+
+    app = Sanic('fail_url_build')
+
+    @app.route(url)
+    def fail():
+        return text('this should fail')
+
+    fail_args = list(string.ascii_letters)
+    fail_args.pop()
+
+    fail_kwargs = {l: l for l in fail_args}
+
+    with pytest.raises(URLBuildError) as e:
+        app.url_for('fail', **fail_kwargs)
+
+    assert 'Required parameter `Z` was not passed to url_for' in str(e.value)
+
+
+COMPLEX_PARAM_URL = (
+    '/<foo:int>/<four_letter_string:[A-z]{4}>/'
+    '<two_letter_string:[A-z]{2}>/<normal_string>/<some_number:number>')
+PASSING_KWARGS = {
+    'foo': 4, 'four_letter_string': 'woof',
+    'two_letter_string': 'ba', 'normal_string': 'normal',
+    'some_number': '1.001'}
+EXPECTED_BUILT_URL = '/4/woof/ba/normal/1.001'
+
+
+def test_fails_with_int_message():
+    app = Sanic('fail_url_build')
+
+    @app.route(COMPLEX_PARAM_URL)
+    def fail():
+        return text('this should fail')
+
+    failing_kwargs = dict(PASSING_KWARGS)
+    failing_kwargs['foo'] = 'not_int'
+
+    with pytest.raises(URLBuildError) as e:
+        app.url_for('fail', **failing_kwargs)
+
+    expected_error = (
+        'Value "not_int" for parameter `foo` '
+        'does not match pattern for type `int`: \d+')
+    assert str(e.value) == expected_error
+
+
+def test_fails_with_two_letter_string_message():
+    app = Sanic('fail_url_build')
+
+    @app.route(COMPLEX_PARAM_URL)
+    def fail():
+        return text('this should fail')
+
+    failing_kwargs = dict(PASSING_KWARGS)
+    failing_kwargs['two_letter_string'] = 'foobar'
+
+    with pytest.raises(URLBuildError) as e:
+        app.url_for('fail', **failing_kwargs)
+
+    expected_error = (
+        'Value "foobar" for parameter `two_letter_string` '
+        'does not satisfy pattern [A-z]{2}')
+
+    assert str(e.value) == expected_error
+
+
+def test_fails_with_number_message():
+    app = Sanic('fail_url_build')
+
+    @app.route(COMPLEX_PARAM_URL)
+    def fail():
+        return text('this should fail')
+
+    failing_kwargs = dict(PASSING_KWARGS)
+    failing_kwargs['some_number'] = 'foo'
+
+    with pytest.raises(URLBuildError) as e:
+        app.url_for('fail', **failing_kwargs)
+
+    expected_error = (
+        'Value "foo" for parameter `some_number` '
+        'does not match pattern for type `float`: [0-9\\\\.]+')
+
+    assert str(e.value) == expected_error
+
+
+def test_adds_other_supplied_values_as_query_string():
+    app = Sanic('passes')
+
+    @app.route(COMPLEX_PARAM_URL)
+    def passes():
+        return text('this should pass')
+
+    new_kwargs = dict(PASSING_KWARGS)
+    new_kwargs['added_value_one'] = 'one'
+    new_kwargs['added_value_two'] = 'two'
+
+    url = app.url_for('passes', **new_kwargs)
+
+    query = dict(parse_qsl(urlsplit(url).query))
+
+    assert query['added_value_one'] == 'one'
+    assert query['added_value_two'] == 'two'
+
+
+@pytest.fixture
+def blueprint_app():
+    app = Sanic('blueprints')
+
+    first_print = Blueprint('first', url_prefix='/first')
+    second_print = Blueprint('second', url_prefix='/second')
+
+    @first_print.route('/foo')
+    def foo():
+        return text('foo from first')
+
+    @first_print.route('/foo/<param>')
+    def foo_with_param(request, param):
+        return text(
+            'foo from first : {}'.format(param))
+
+    @second_print.route('/foo') # noqa
+    def foo():
+        return text('foo from second')
+
+    @second_print.route('/foo/<param>') # noqa
+    def foo_with_param(request, param):
+        return text(
+            'foo from second : {}'.format(param))
+
+    app.blueprint(first_print)
+    app.blueprint(second_print)
+
+    return app
+
+
+def test_blueprints_are_named_correctly(blueprint_app):
+    first_url = blueprint_app.url_for('first.foo')
+    assert first_url == '/first/foo'
+
+    second_url = blueprint_app.url_for('second.foo')
+    assert second_url == '/second/foo'
+
+
+def test_blueprints_work_with_params(blueprint_app):
+    first_url = blueprint_app.url_for('first.foo_with_param', param='bar')
+    assert first_url == '/first/foo/bar'
+
+    second_url = blueprint_app.url_for('second.foo_with_param', param='bar')
+    assert second_url == '/second/foo/bar'
+
+
+@pytest.fixture
+def methodview_app():
+    app = Sanic('methodview')
+
+    class ViewOne(HTTPMethodView):
+        def get(self, request):
+            return text('I am get method')
+
+        def post(self, request):
+            return text('I am post method')
+
+        def put(self, request):
+            return text('I am put method')
+
+        def patch(self, request):
+            return text('I am patch method')
+
+        def delete(self, request):
+            return text('I am delete method')
+
+    app.add_route(ViewOne.as_view('view_one'), '/view_one')
+
+    class ViewTwo(HTTPMethodView):
+        def get(self, request):
+            return text('I am get method')
+
+        def post(self, request):
+            return text('I am post method')
+
+        def put(self, request):
+            return text('I am put method')
+
+        def patch(self, request):
+            return text('I am patch method')
+
+        def delete(self, request):
+            return text('I am delete method')
+
+    app.add_route(ViewTwo.as_view(), '/view_two')
+
+    return app
+
+
+def test_methodview_naming(methodview_app):
+    viewone_url = methodview_app.url_for('ViewOne')
+    viewtwo_url = methodview_app.url_for('ViewTwo')
+
+    assert viewone_url == '/view_one'
+    assert viewtwo_url == '/view_two'


### PR DESCRIPTION
Adds in a `url_for` method to generate URLs based on an endpoint's handler name, similar to Flask. Provides the same type of functionality as Flask, but will additionally fail URL building if a supplied parameter does not pass the request parameter pattern. From the docs I wrote:

> 
> Sanic provides a `url_for` method, to generate URLs based on the handler method name. This is useful if you want to avoid hardcoding url paths into your app; instead, you can just reference the handler name. For example:
> 
> ```python
> @app.route('/')
> async def index(request):
>     # generate a URL for the endpoint `post_handler`
>     url = app.url_for('post_handler', post_id=5)
>     # the URL is `/posts/5`, redirect to it
>     return redirect(url)
> 
> 
> @app.route('/posts/<post_id>')
> async def post_handler(request, post_id):
>     return text('Post - {}'.format(post_id))
> ```
> 
> Other things to keep in mind when using `url_for`:
> 
> - Keyword arguments passed to `url_for` that are not request parameters will be included in the URL's query string. For example:
> ```python
> url = app.url_for('post_handler', post_id=5, arg_one='one', arg_two='two')
> # /posts/5?arg_one=one&arg_two=two
> ```
> - All valid parameters must be passed to `url_for` to build a URL. If a parameter is not supplied, or if a parameter does not match the specified type, a `URLBuildError` will be thrown.

Caveats: I did not try to make this work with `static` files or the `CompositionView`. The reason is I found no logical pattern for getting a view name for `static` handlers, since there is no unique "handler" surrounding a static file. Same for `CompositionView` handlers. 

One possible idea would be to force the naming of a class based view, like Flask does:

`app.add_route(SpecialClassView.as_view('special_class_name'), '/special_class_view')`

Another idea would be to make the static file API similar to routing, with unique handlers:

```
@app.static(/static/images/<image_file>)
def image_file():
   ...
```
But these were out of scope for this request.

Fixes #336 