### PR TITLE
improve url_for to support multi values and special options

### DIFF
--- a/docs/sanic/routing.md
+++ b/docs/sanic/routing.md
@@ -11,7 +11,7 @@ from sanic.response import json
 @app.route("/")
 async def test(request):
     return json({ "hello": "world" })
-``` 
+```
 
 When the url `http://server.url/` is accessed (the base url of the server), the
 final `/` is matched by the router to the handler function, `test`, which then
@@ -144,6 +144,28 @@ Other things to keep in mind when using `url_for`:
 ```python
 url = app.url_for('post_handler', post_id=5, arg_one='one', arg_two='two')
 # /posts/5?arg_one=one&arg_two=two
+```
+- Multivalue argument can be passed to `url_for`. For example:
+```python
+url = app.url_for('post_handler', post_id=5, arg_one=['one', 'two'])
+# /posts/5?arg_one=one&arg_one=two
+```
+- Also some special arguments (`_anchor`, `_external`, `_scheme`, `_method`, `_server`) passed to `url_for` will have special url building (`_method` is not support now and will be ignored). For example:
+```python
+url = app.url_for('post_handler', post_id=5, arg_one='one', _anchor='anchor')
+# /posts/5?arg_one=one#anchor
+
+url = app.url_for('post_handler', post_id=5, arg_one='one', _external=True)
+# //server/posts/5?arg_one=one
+# _external requires passed argument _server or SERVER_NAME in app.config or url will be same as no _external
+
+url = app.url_for('post_handler', post_id=5, arg_one='one', _scheme='http', _external=True)
+# http://server/posts/5?arg_one=one
+# when specifying _scheme, _external must be True
+
+# you can pass all special arguments one time
+url = app.url_for('post_handler', post_id=5, arg_one=['one', 'two'], arg_two=2, _anchor='anchor', _scheme='http', _external=True, _server='another_server:8888')
+# http://another_server:8888/posts/5?arg_one=one&arg_one=two&arg_two=2#anchor
 ```
 - All valid parameters must be passed to `url_for` to build a URL. If a parameter is not supplied, or if a parameter does not match the specified type, a `URLBuildError` will be thrown.
 

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -239,7 +239,10 @@ class Sanic:
         if scheme and not external:
             raise ValueError('When specifying _scheme, _external must be True')
 
-        netloc = kwargs.pop('_server', self.config.get('SERVER_NAME', ''))
+        netloc = kwargs.pop('_server', None)
+        if netloc is None and external:
+            netloc = self.config.get('SERVER_NAME', '')
+
         for match in matched_params:
             name, _type, pattern = self.router.parse_parameter_string(
                 match)

--- a/sanic/sanic.py
+++ b/sanic/sanic.py
@@ -283,10 +283,9 @@ class Sanic:
                 replacement_regex, supplied_param, out)
 
         # parse the remainder of the keyword arguments into a querystring
-        if kwargs:
-            query_string = urlencode(kwargs, doseq=True)
-            # scheme://netloc/path;parameters?query#fragment
-            out = urlunparse((scheme, netloc, out, '', query_string, anchor))
+        query_string = urlencode(kwargs, doseq=True) if kwargs else ''
+        # scheme://netloc/path;parameters?query#fragment
+        out = urlunparse((scheme, netloc, out, '', query_string, anchor))
 
         return out
 

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -6,7 +6,11 @@ PORT = 42101
 
 
 async def local_request(method, uri, cookies=None, *args, **kwargs):
-    url = 'http://{host}:{port}{uri}'.format(host=HOST, port=PORT, uri=uri)
+    if uri.startswith(('http:', 'https:', 'ftp:', 'ftps://' '//')):
+        url = uri
+    else:
+        url = 'http://{host}:{port}{uri}'.format(host=HOST, port=PORT, uri=uri)
+
     log.info(url)
     async with aiohttp.ClientSession(cookies=cookies) as session:
         async with getattr(


### PR DESCRIPTION
improve `url_for` to support multi values for one arg, such as `arg1=value1&arg1=value2`, add `_anchor`/`_external`/`_scheme` options

option `_method` can be passed but will be ignored as I have no idea how to implement it.