### PR TITLE
Enhance error logging

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -179,7 +179,8 @@ class HttpProtocol(asyncio.Protocol):
                     self.request.ip))
         except Exception as e:
             self.bail_out(
-                "Writing response failed, connection closed {}".format(e))
+                "Writing response failed, connection closed {}".format(
+                    repr(e)))
         finally:
             if not keep_alive:
                 self.transport.close()
@@ -196,10 +197,10 @@ class HttpProtocol(asyncio.Protocol):
         except RuntimeError:
             log.error(
                 'Connection lost before error written @ {}'.format(
-                    self.request.ip))
+                    self.request.ip if self.request else 'Unknown'))
         except Exception as e:
             self.bail_out(
-                "Writing error failed, connection closed {}".format(e),
+                "Writing error failed, connection closed {}".format(repr(e)),
                 from_error=True)
         finally:
             self.transport.close()


### PR DESCRIPTION
- Prevent to fall into error logging recursion when it doesn't have
request info (Print 'Unknown' when the request is still `None`
- Print repr(e) rather than str(e)