### PR TITLE
Header performance gains

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -1,4 +1,3 @@
-from collections import ChainMap
 from mimetypes import guess_type
 from os import path
 from ujson import dumps as json_dumps


### PR DESCRIPTION
Changes from #378 introduced about a 10k request/sec slowdown. This
tries to rememdy it while keeping the same functionality but it's still
not as fast as 0.3.1

With the normal benchmarking I get about:
```console
Running 10s test @ http://localhost:8000
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.92ms  673.12us   9.52ms   78.07%
    Req/Sec    17.10k   605.41    18.11k    72.50%
  340654 requests in 10.02s, 40.28MB read
Requests/sec:  34010.41
Transfer/sec:      4.02MB
```