### PR TITLE
support view instance for blueprint add_route method

### DIFF
--- a/docs/sanic/blueprints.md
+++ b/docs/sanic/blueprints.md
@@ -131,8 +131,8 @@ can be used to implement our API versioning scheme.
 from sanic.response import text
 from sanic import Blueprint
 
-blueprint_v1 = Blueprint('v1')
-blueprint_v2 = Blueprint('v2')
+blueprint_v1 = Blueprint('v1', url_prefix='/v1')
+blueprint_v2 = Blueprint('v2', url_prefix='/v2')
 
 @blueprint_v1.route('/')
 async def api_v1_root(request):

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -86,7 +86,7 @@ class Blueprint:
     def add_route(self, handler, uri, methods=frozenset({'GET'}), host=None):
         """
         Creates a blueprint route from a function.
-        :param handler: function or class instance to handle uri request.
+        :param handler: Function or class instance to handle uri request.
         :param uri: Endpoint at which the route will be accessible.
         :param methods: List of acceptable HTTP methods.
         :return: function or class instance

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -87,7 +87,8 @@ class Blueprint:
     def add_route(self, handler, uri, methods=frozenset({'GET'}), host=None):
         """
         Creates a blueprint route from a function.
-        :param handler: Function for handling uri requests. Accepts function, or class instance with a view_class method.
+        :param handler: Function for handling uri requests. Accepts function,
+                        or class instance with a view_class method.
         :param uri: Endpoint at which the route will be accessible.
         :param methods: List of acceptable HTTP methods.
         :return: function or class instance


### PR DESCRIPTION
- make blueprint add_route method support view instance
- update documentation that doesn't specify url_prefix parameter