### PR TITLE
Bugfix & simplfication for host based routing

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict, namedtuple
-from collections.abc import Collection
+from collections.abc import Iterable
 from functools import lru_cache
 from .exceptions import NotFound, InvalidUsage
 from .views import CompositionView
@@ -112,8 +112,8 @@ class Router:
                 self.hosts.add(host)
 
             else:
-                if not isinstance(host, Collection):
-                    raise ValueError("Expected either string of Collection of "
+                if not isinstance(host, Iterable):
+                    raise ValueError("Expected either string or Iterable of "
                                      "host strings, not {!r}".format(host))
 
                 for host_ in host:


### PR DESCRIPTION
If a list of hosts is passed after a previous vhost route was added, Sanic previously attempted to add set to set, raising an TypeError.
This is fixed, and I added comment documenting substandard behaviour.

Example:
```python

from sanic import Sanic
from sanic.response import text
from sanic.utils import sanic_endpoint_test

app = Sanic('test_vhosts')

@app.route('/', host="google.com")
async def handler(request):
    return text("Hello, world!")

@app.route('/', host=["hello.com", "world.com"])
async def handler(request):
    return text("Hello, world!")

app.run()
```

This doesn't attempt to fix the bigger issue with routing, which is that if _any_ routes provide host based routing, all need to support it, and no default host-less case can be specified.