### PR TITLE
Add app loop safety

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -57,11 +57,14 @@ class Sanic:
 
     @property
     def loop(self):
-        """Synonymous with asyncio.get_event_loop()."""
+        """Synonymous with asyncio.get_event_loop().
+
+        Only supported when using the `app.run` method.
+        """
         if not self.is_running:
             raise SanicException(
                 'Loop can only be retrieved after the app has started '
-                'running or when not run asynchronously')
+                'running. Not supported with `create_server` function')
         return get_event_loop()
 
     # -------------------------------------------------------------------- #

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -527,7 +527,6 @@ class Sanic:
 
         self.error_handler.debug = debug
         self.debug = debug
-        loop = self.loop
 
         server_settings = {
             'protocol': protocol,


### PR DESCRIPTION
`app.loop` should only be useable when the app is actually running.

This PR solves for that.

Also adds some docstrings surrounding `create_server`