### PR TITLE
Add `stream` method for streaming content, add docs and examples

### DIFF
--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -11,8 +11,8 @@ app = Sanic(__name__)
 @app.route("/")
 async def test(request):
     async def sample_streaming_fn(response):
-        await response.write('foo,')
-        await response.write('bar')
+        response.write('foo,')
+        response.write('bar')
 
     return stream(sample_streaming_fn, content_type='text/csv')
 ```
@@ -26,7 +26,7 @@ async def index(request):
         conn = await asyncpg.connect(database='test')
         async with conn.transaction():
             async for record in conn.cursor('SELECT generate_series(0, 10)'):
-                await response.write(record[0])
+                response.write(record[0])
 
     return stream(stream_from_db)
 ```

--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -1,0 +1,29 @@
+# Streaming
+
+Sanic allows you to stream content to the client with the `stream` method. This method accepts a coroutine callback which is passed a `StreamingHTTPResponse` object that is written to. A simple example is like follows:
+
+```python
+app = Sanic(__name__)
+
+@app.route("/")
+async def test(request):
+    async def sample_streaming_fn(response):
+        await response.write('foo,')
+        await response.write('bar')
+
+    return stream(sample_streaming_fn, content_type='text/csv')
+```
+
+This is useful in situations where you want to stream content to the client that originates in an external service, like a database. For example, you can stream database records to the client with the asynchronous cursor that `asyncpg` provides:
+
+```python
+@app.route("/")
+async def index(request):
+    async def stream_from_db(response):
+        conn = await asyncpg.connect(database='test')
+        async with conn.transaction():
+            async for record in conn.cursor('SELECT generate_series(0, 10)'):
+                await response.write(record[0])
+
+    return stream(stream_from_db)
+```

--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -3,6 +3,9 @@
 Sanic allows you to stream content to the client with the `stream` method. This method accepts a coroutine callback which is passed a `StreamingHTTPResponse` object that is written to. A simple example is like follows:
 
 ```python
+from sanic import Sanic
+from sanic.response import stream
+
 app = Sanic(__name__)
 
 @app.route("/")

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -416,7 +416,7 @@ class Sanic:
                     response = HTTPResponse(
                         "An error occurred while handling an error")
 
-        response_callback(response)
+        await response_callback(response)
 
     # -------------------------------------------------------------------- #
     # Testing

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -1,7 +1,5 @@
-import asyncio
 from mimetypes import guess_type
 from os import path
-from inspect import isawaitable
 from ujson import dumps as json_dumps
 
 from aiofiles import open as open_async

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -109,19 +109,21 @@ class StreamingHTTPResponse(BaseHTTPResponse):
         'status', 'content_type', 'headers', '_cookies')
 
     def __init__(self, streaming_fn, status=200, headers=None,
-                 content_type='text/plain', body_bytes=b''):
+                 content_type='text/plain'):
         self.content_type = content_type
         self.streaming_fn = streaming_fn
         self.status = status
         self.headers = headers or {}
         self._cookies = None
 
-    async def write(self, data):
+    def write(self, data):
         """Writes a chunk of data to the streaming response.
 
         :param data: bytes-ish data to be written.
         """
-        data = self._encode_body(data)
+        if type(data) != bytes:
+            data = self._encode_body(data)
+
         self.transport.write(
             b"%b\r\n%b\r\n" % (str(len(data)).encode(), data))
 

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -21,7 +21,6 @@ except ImportError:
 
 from sanic.log import log
 from sanic.request import Request
-from sanic.response import StreamingHTTPResponse
 from sanic.exceptions import (
     RequestTimeout, PayloadTooLarge, InvalidUsage, ServerError)
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,8 +1,12 @@
+import asyncio
+import pytest
 from random import choice
 
 from sanic import Sanic
-from sanic.response import HTTPResponse
+from sanic.response import HTTPResponse, stream, StreamingHTTPResponse
+from sanic.testing import HOST, PORT
 
+from unittest.mock import MagicMock
 
 def test_response_body_not_a_string():
     """Test when a response body sent from the application is not a string"""
@@ -15,3 +19,78 @@ def test_response_body_not_a_string():
 
     request, response = app.test_client.get('/hello')
     assert response.text == str(random_num)
+
+
+async def sample_streaming_fn(response):
+    await response.write('foo,')
+    await asyncio.sleep(.001)
+    await response.write('bar')
+
+
+@pytest.fixture
+def streaming_app():
+    app = Sanic('streaming')
+
+    @app.route("/")
+    async def test(request):
+        return stream(sample_streaming_fn, content_type='text/csv')
+
+    return app
+
+
+def test_streaming_adds_correct_headers(streaming_app):
+    request, response = streaming_app.test_client.get('/')
+    assert response.headers['Transfer-Encoding'] == 'chunked'
+    assert response.headers['Content-Type'] == 'text/csv'
+
+
+def test_streaming_returns_correct_content(streaming_app):
+    request, response = streaming_app.test_client.get('/')
+    assert response.text == 'foo,bar'
+
+
+@pytest.mark.parametrize('status', [200, 201, 400, 401])
+def test_stream_response_status_returns_correct_headers(status):
+    response = StreamingHTTPResponse(sample_streaming_fn, status=status)
+    headers = response.get_headers()
+    assert b"HTTP/1.1 %s" % str(status).encode() in headers
+
+
+@pytest.mark.parametrize('keep_alive_timeout', [10, 20, 30])
+def test_stream_response_keep_alive_returns_correct_headers(
+        keep_alive_timeout):
+    response = StreamingHTTPResponse(sample_streaming_fn)
+    headers = response.get_headers(
+        keep_alive=True, keep_alive_timeout=keep_alive_timeout)
+
+    assert b"Keep-Alive: %s\r\n" % str(keep_alive_timeout).encode() in headers
+
+
+def test_stream_response_includes_chunked_header():
+    response = StreamingHTTPResponse(sample_streaming_fn)
+    headers = response.get_headers()
+    assert b"Transfer-Encoding: chunked\r\n" in headers
+
+
+def test_stream_response_writes_correct_content_to_transport(streaming_app):
+    response = StreamingHTTPResponse(sample_streaming_fn)
+    response.transport = MagicMock(asyncio.Transport)
+
+    @streaming_app.listener('after_server_start')
+    async def run_stream(app, loop):
+        await response.stream()
+        assert response.transport.write.call_args_list[1][0][0] == (
+            b'4\r\nfoo,\r\n'
+        )
+
+        assert response.transport.write.call_args_list[2][0][0] == (
+            b'3\r\nbar\r\n'
+        )
+
+        assert response.transport.write.call_args_list[3][0][0] == (
+            b'0\r\n\r\n'
+        )
+
+        app.stop()
+
+    streaming_app.run(host=HOST, port=PORT)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -22,9 +22,9 @@ def test_response_body_not_a_string():
 
 
 async def sample_streaming_fn(response):
-    await response.write('foo,')
+    response.write('foo,')
     await asyncio.sleep(.001)
-    await response.write('bar')
+    response.write('bar')
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds in a new Response type, `StreamingHTTPResponse`, which can be asynchronously written to by a coroutine callback and streamed to the client. 

I made a purposeful attempt to avoid interfering with the main `write_response` path. This adds a new `HttpProtocol.stream_response` method that is passed as a callback to `Sanic.handle_request`. Inside `Sanic.handle_request` an instance check is made to determine if the response should be streamed or synchronously written to the transport, so performance remains the same.

Before this PR:

```
(sanic) sraman@sraman: sanic$ wrk http://127.0.0.1:8000/
Running 10s test @ http://127.0.0.1:8000/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.30ms  527.77us  10.43ms   91.70%
    Req/Sec     2.18k   125.53     2.36k    78.50%
  43427 requests in 10.01s, 5.30MB read
Requests/sec:   4337.96
Transfer/sec:    542.25KB
```

After this PR:

```
(sanic) sraman@sraman: sanic$ wrk http://127.0.0.1:8000/
Running 10s test @ http://127.0.0.1:8000/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.30ms  427.62us  10.79ms   90.26%
    Req/Sec     2.18k   111.73     2.33k    73.50%
  43397 requests in 10.01s, 5.30MB read
Requests/sec:   4334.05
Transfer/sec:    541.76KB
```

From the docs I wrote:

> # Streaming
> 
> Sanic allows you to stream content to the client with the `stream` method. This method accepts a coroutine callback which is passed a `StreamingHTTPResponse` object that is written to. A simple example is like follows:
> 
> ```python
> from sanic import Sanic
> from sanic.response import stream
> 
> app = Sanic(__name__)
> 
> @app.route("/")
> async def test(request):
>     async def sample_streaming_fn(response):
>         response.write('foo,')
>         response.write('bar')
> 
>     return stream(sample_streaming_fn, content_type='text/csv')
> ```
> 
> This is useful in situations where you want to stream content to the client that originates in an external service, like a database. For example, you can stream database records to the client with the asynchronous cursor that `asyncpg` provides:
> 
> ```python
> @app.route("/")
> async def index(request):
>     async def stream_from_db(response):
>         conn = await asyncpg.connect(database='test')
>         async with conn.transaction():
>             async for record in conn.cursor('SELECT generate_series(0, 10)'):
>                 response.write(record[0])
> 
>     return stream(stream_from_db)
> ```