### PR TITLE
Make Sanic app instance accessible to blueprint

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -18,6 +18,7 @@ class Blueprint:
         :param name: unique name of the blueprint
         :param url_prefix: URL to be prefixed before all route URLs
         """
+        self.app = None
         self.name = name
         self.url_prefix = url_prefix
         self.host = host
@@ -31,6 +32,7 @@ class Blueprint:
     def register(self, app, options):
         """Register the blueprint to the sanic app."""
 
+        self.app = app
         url_prefix = options.get('url_prefix', self.url_prefix)
 
         # Routes

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -308,3 +308,18 @@ def test_bp_shorthand():
 
     request, response = app.test_client.get('/delete')
     assert response.status == 405
+
+
+def test_bp_access_app_config():
+    app = Sanic('test_access_app_config')
+    app.config.TEXT = 'Hello'
+    bp = Blueprint('test_access_app_config')
+
+    @bp.route('/')
+    def handler(request):
+        return text(bp.app.config.TEXT)
+
+    app.blueprint(bp)
+    request, response = app.test_client.get('/')
+
+    assert response.text == 'Hello'


### PR DESCRIPTION
Blueprints are supposed to be some kind of pluggable components, it should be able to access current app instance to read configurations and do other useful things.