### PR TITLE
url_for has something wrong with //

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -270,7 +270,7 @@ class Sanic:
                     'Endpoint with name `{}` was not found'.format(
                         view_name))
 
-        if uri.endswith('/'):
+        if uri != '/' and uri.endswith('/'):
             uri = uri[:-1]
 
         out = uri

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -41,7 +41,7 @@ class Blueprint:
             # Prepend the blueprint URI prefix if available
             uri = url_prefix + future.uri if url_prefix else future.uri
             app.route(
-                uri=uri,
+                uri=uri[1:] if uri.startswith('//') else uri,
                 methods=future.methods,
                 host=future.host or self.host
                 )(future.handler)


### PR DESCRIPTION
`url_for` not works on below code:
```python

bp = Blueprint('home', url_prefix='/')

@bp.route('/')
async def index(request):
    pass

@bp.route('/login')
async def login(request):
    pass

app.blueprint(bp)

# url_for('home.login') will get '//login'
# @bp.route('/login') must be @bp.route('login') to make it work
# after the merge, both ways will be work
```