### PR TITLE
Rework logging

### DIFF
--- a/examples/cache_example.py
+++ b/examples/cache_example.py
@@ -9,16 +9,17 @@ If you want more info about the package check
 https://github.com/argaen/aiocache
 """
 
+import logging
 import asyncio
 import aiocache
 
 from sanic import Sanic
 from sanic.response import json
-from sanic.log import log
 from aiocache import cached
 from aiocache.serializers import JsonSerializer
 
 app = Sanic(__name__)
+log = logging.getLogger(__name__)
 
 
 @app.listener('before_server_start')

--- a/examples/try_everything.py
+++ b/examples/try_everything.py
@@ -1,11 +1,12 @@
 import os
+import logging
 
 from sanic import Sanic
-from sanic.log import log
 from sanic.response import json, text, file
 from sanic.exceptions import ServerError
 
 app = Sanic(__name__)
+log = logging.getLogger(__name__)
 
 
 @app.route("/")

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,8 +1,12 @@
+import logging
 from argparse import ArgumentParser
 from importlib import import_module
 
-from sanic.log import log
 from sanic.app import Sanic
+
+
+log = logging.getLogger('sanic')
+
 
 if __name__ == "__main__":
     parser = ArgumentParser(prog='sanic')

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -12,13 +12,15 @@ from sanic.config import Config
 from sanic.constants import HTTP_METHODS
 from sanic.exceptions import ServerError, URLBuildError, SanicException
 from sanic.handlers import ErrorHandler
-from sanic.log import log
 from sanic.response import HTTPResponse
 from sanic.router import Router
 from sanic.server import serve, serve_multiple, HttpProtocol
 from sanic.static import register as static_register
 from sanic.testing import TestClient
 from sanic.views import CompositionView
+
+
+log = logging.getLogger(__name__)
 
 
 class Sanic:

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 from traceback import format_exc, extract_tb
 
 from sanic.exceptions import (
@@ -10,8 +11,9 @@ from sanic.exceptions import (
     TRACEBACK_LINE_HTML,
     TRACEBACK_STYLE,
     TRACEBACK_WRAPPER_HTML)
-from sanic.log import log
 from sanic.response import text, html
+
+log = logging.getLogger(__name__)
 
 
 class ErrorHandler:

--- a/sanic/log.py
+++ b/sanic/log.py
@@ -1,3 +1,0 @@
-import logging
-
-log = logging.getLogger('sanic')

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -1,3 +1,4 @@
+import logging
 from cgi import parse_header
 from collections import namedtuple
 from http.cookies import SimpleCookie
@@ -10,9 +11,9 @@ except ImportError:
     from json import loads as json_loads
 
 from sanic.exceptions import InvalidUsage
-from sanic.log import log
 
 
+log = logging.getLogger(__name__)
 DEFAULT_HTTP_CONTENT_TYPE = "application/octet-stream"
 # HTTP/1.1: https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7.2.1
 # > If the media type remains unknown, the recipient SHOULD treat it

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import logging
 import traceback
 import warnings
 from functools import partial
@@ -19,11 +20,11 @@ try:
 except ImportError:
     async_loop = asyncio
 
-from sanic.log import log
 from sanic.request import Request
 from sanic.exceptions import (
     RequestTimeout, PayloadTooLarge, InvalidUsage, ServerError)
 
+log = logging.getLogger(__name__)
 current_time = None
 
 

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -1,5 +1,7 @@
-from sanic.log import log
+import logging
 
+
+log = logging.getLogger(__name__)
 HOST = '127.0.0.1'
 PORT = 42101
 


### PR DESCRIPTION
Refs:

https://fangpenlin.com/posts/2012/08/26/good-logging-practice-in-python/

http://docs.python-guide.org/en/latest/writing/logging/#logging-in-a-library

Currently use the `sanic.log.log` is misleading, seeing some logs like:

```
2017-02-24 06:43:14,827 ERROR Process-15055 MainThread sanic.log:71    NoneType: None
```

logging configuration:

```python
LOGGING = {
    'version': 1,
    'disable_existing_loggers': False,
    'root': {
        'handlers': ['console'],
        'level': 'DEBUG'
    },
    'handlers': {
        'console': {
            'level': 'DEBUG',
            'class': 'logging.StreamHandler',
            'formatter': 'default',
            'stream': sys.stderr,
        }
    },
    'formatters': {
        'default': {
            'format': '%(asctime)s %(levelname)-2s Process-%(process)d %(threadName)s %(name)s.%(funcName)s:%(lineno)-5d %(message)s',  # NOQA
        },
    },
}
logging.config.dictConfig(LOGGING)
```

I don't really know what is going on, `sanic.log` module has only 3 lines of codes, makes it hard to debug.