### PR TITLE
The loop argument of serve()

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -298,7 +298,7 @@ def serve(host, port, request_handler, error_handler, before_start=None,
     :param protocol: subclass of asyncio protocol class
     :return: Nothing
     """
-    if not run_async:
+    if not loop:
         loop = async_loop.new_event_loop()
         asyncio.set_event_loop(loop)
 


### PR DESCRIPTION
I suppose that a new loop should be created only if the loop argument is not provided