### PR TITLE
remove stop_event

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -554,19 +554,24 @@ class Sanic:
         if protocol is None:
             protocol = (WebSocketProtocol if self.websocket_enabled
                         else HttpProtocol)
+        if stop_event is not None:
+            if debug:
+                warnings.simplefilter('default')
+            warnings.warn("stop_event will be removed from future versions.",
+                          DeprecationWarning)
         server_settings = self._helper(
             host=host, port=port, debug=debug, before_start=before_start,
             after_start=after_start, before_stop=before_stop,
             after_stop=after_stop, ssl=ssl, sock=sock, workers=workers,
             loop=loop, protocol=protocol, backlog=backlog,
-            stop_event=stop_event, register_sys_signals=register_sys_signals)
+            register_sys_signals=register_sys_signals)
 
         try:
             self.is_running = True
             if workers == 1:
                 serve(**server_settings)
             else:
-                serve_multiple(server_settings, workers, stop_event)
+                serve_multiple(server_settings, workers)
         except:
             log.exception(
                 'Experienced exception while trying to serve')
@@ -592,16 +597,23 @@ class Sanic:
         NOTE: This does not support multiprocessing and is not the preferred
               way to run a Sanic application.
         """
+<<<<<<< df9884de3c7ca6ad248162c8f404afd0ed774359
         if protocol is None:
             protocol = (WebSocketProtocol if self.websocket_enabled
                         else HttpProtocol)
+=======
+        if stop_event is not None:
+            if debug:
+                warnings.simplefilter('default')
+            warnings.warn("stop_event will be removed from future versions.",
+                          DeprecationWarning)
+>>>>>>> remove stop_event
         server_settings = self._helper(
             host=host, port=port, debug=debug, before_start=before_start,
             after_start=after_start, before_stop=before_stop,
             after_stop=after_stop, ssl=ssl, sock=sock,
             loop=loop or get_event_loop(), protocol=protocol,
-            backlog=backlog, stop_event=stop_event,
-            run_async=True)
+            backlog=backlog, run_async=True)
 
         return await serve(**server_settings)
 
@@ -611,6 +623,7 @@ class Sanic:
                 protocol=HttpProtocol, backlog=100, stop_event=None,
                 register_sys_signals=True, run_async=False):
         """Helper function used by `run` and `create_server`."""
+<<<<<<< df9884de3c7ca6ad248162c8f404afd0ed774359
 
         if isinstance(ssl, dict):
             # try common aliaseses
@@ -622,6 +635,13 @@ class Sanic:
             context.load_cert_chain(cert, keyfile=key)
             ssl = context
 
+=======
+        if stop_event is not None:
+            if debug:
+                warnings.simplefilter('default')
+            warnings.warn("stop_event will be removed from future versions.",
+                          DeprecationWarning)
+>>>>>>> remove stop_event
         if loop is not None:
             if debug:
                 warnings.simplefilter('default')

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -4,10 +4,13 @@ import traceback
 import warnings
 from functools import partial
 from inspect import isawaitable
-from multiprocessing import Process, Event
+from multiprocessing import Process
 from os import set_inheritable
-from signal import SIGTERM, SIGINT
-from signal import signal as signal_func
+from signal import (
+    SIGTERM, SIGINT,
+    signal as signal_func,
+    Signals
+)
 from socket import socket, SOL_SOCKET, SO_REUSEADDR
 from time import time
 
@@ -421,7 +424,7 @@ def serve(host, port, request_handler, error_handler, before_start=None,
         loop.close()
 
 
-def serve_multiple(server_settings, workers, stop_event=None):
+def serve_multiple(server_settings, workers):
     """Start multiple server processes simultaneously.  Stop on interrupt
     and terminate signals, and drain connections when complete.
 
@@ -448,11 +451,12 @@ def serve_multiple(server_settings, workers, stop_event=None):
         server_settings['host'] = None
         server_settings['port'] = None
 
-    if stop_event is None:
-        stop_event = Event()
+    def sig_handler(signal, frame):
+        log.info("Received signal {}. Shutting down.".format(
+            Signals(signal).name))
 
-    signal_func(SIGINT, lambda s, f: stop_event.set())
-    signal_func(SIGTERM, lambda s, f: stop_event.set())
+    signal_func(SIGINT, lambda s, f: sig_handler(s, f))
+    signal_func(SIGTERM, lambda s, f: sig_handler(s, f))
 
     processes = []
     for _ in range(workers):


### PR DESCRIPTION
This is doing precisely nothing so we should remove it unless someone voices a strong argument for keeping it.

To witness it doing nothing, use the below example:

```python
from sanic import Sanic
from sanic.response import json, text
from multiprocessing import Event

stop_event = Event()

app = Sanic(__name__)

@app.route("/")
async def test(request):
    stop_event.set()
    return text('ok')

app.run(host="0.0.0.0", port=8000, debug=True, workers=2, stop_event=stop_event)
```

This should stop after handling the first request, but does not.