### PR TITLE
rate limiting for sanic

### DIFF
--- a/docs/sanic/extensions.md
+++ b/docs/sanic/extensions.md
@@ -12,3 +12,4 @@ A list of Sanic extensions created by the community.
 - [Motor](https://github.com/lixxu/sanic-motor): Simple motor wrapper.
 - [Sanic CRUD](https://github.com/Typhon66/sanic_crud): CRUD REST API generation with peewee models.
 - [UserAgent](https://github.com/lixxu/sanic-useragent): Add `user_agent` to request
+- [Limiter](https://github.com/bohea/sanic-limiter): Rate limiting for sanic.


### PR DESCRIPTION
A rate limiting extension inspired by flask-limiter Provides rate limiting features for Sanic. 
Supports in-memory, redis and memcache as storage based on alisaifee/limits.

