### PR TITLE
special handling when sock is provided and number of workers > 1

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -396,13 +396,15 @@ def serve_multiple(server_settings, workers, stop_event=None):
                       " has more information.", DeprecationWarning)
     server_settings['reuse_port'] = True
 
-    sock = socket()
-    sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
-    sock.bind((server_settings['host'], server_settings['port']))
-    set_inheritable(sock.fileno(), True)
-    server_settings['sock'] = sock
-    server_settings['host'] = None
-    server_settings['port'] = None
+    # Handling when custom socket is not provided.
+    if server_settings.get('sock') == None:
+        sock = socket()
+        sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+        sock.bind((server_settings['host'], server_settings['port']))
+        set_inheritable(sock.fileno(), True)
+        server_settings['sock'] = sock
+        server_settings['host'] = None
+        server_settings['port'] = None
 
     if stop_event is None:
         stop_event = Event()
@@ -423,6 +425,6 @@ def serve_multiple(server_settings, workers, stop_event=None):
     # the above processes will block this until they're stopped
     for process in processes:
         process.terminate()
-    sock.close()
+    server_settings.get('sock').close()
 
     asyncio.get_event_loop().stop()

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -397,7 +397,7 @@ def serve_multiple(server_settings, workers, stop_event=None):
     server_settings['reuse_port'] = True
 
     # Handling when custom socket is not provided.
-    if server_settings.get('sock') == None:
+    if server_settings.get('sock') is None:
         sock = socket()
         sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
         sock.bind((server_settings['host'], server_settings['port']))


### PR DESCRIPTION
In original implementation, giving a custom sock in run() won't work.
in serve_multiple(), it creates a new sock based on address and port even if sock is provided.
A simple use case would be:

```python
import socket
from sanic import Sanic
from sanic.response import text

app = Sanic(__name__)

@app.route("/")
async def test(request):
    return text("hello")

listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
listener.bind(('0.0.0.0', 8080))
listener.listen(6)

app.run(host=None, port=None, sock=listener, debug=False, workers=6)
```