### PR TITLE
Use cgitb instead of DIY traceback

### DIFF
--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -77,16 +77,6 @@ TRACEBACK_WRAPPER_HTML = '''
     </html>
 '''
 
-TRACEBACK_LINE_HTML = '''
-    <div class="frame-line">
-        <p class="frame-descriptor">
-            File {0.filename}, line <i>{0.lineno}</i>,
-            in <code><b>{0.name}</b></code>
-        </p>
-        <p class="frame-code"><code>{0.line}</code></p>
-    </div>
-'''
-
 INTERNAL_SERVER_ERROR_HTML = '''
     <h1>Internal Server Error</h1>
     <p>


### PR DESCRIPTION
This is a proof-of-concept PR and not done yet.

Will you look into this is useful?
Sanic can remove its own traceback printing code and it is a standard library.
(well, the output html is not very attractive but it is just a debugging tool)