### PR TITLE
fix keep-alive error when sending http pipeline

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -59,7 +59,8 @@ class HttpProtocol(asyncio.Protocol):
         # request config
         'request_handler', 'request_timeout', 'request_max_size',
         # connection management
-        '_total_request_size', '_timeout_handler', '_last_communication_time')
+        '_total_request_size', '_timeout_handler', '_last_communication_time',
+        '_keep_alive')
 
     def __init__(self, *, loop, request_handler, error_handler,
                  signal=Signal(), connections=set(), request_timeout=60,
@@ -80,6 +81,7 @@ class HttpProtocol(asyncio.Protocol):
         self._timeout_handler = None
         self._last_request_time = None
         self._request_handler_task = None
+        self._keep_alive = False
 
     # -------------------------------------------- #
     # Connection
@@ -142,6 +144,9 @@ class HttpProtocol(asyncio.Protocol):
             exception = PayloadTooLarge('Payload Too Large')
             self.write_error(exception)
 
+        if name == b'Connection':
+            self._keep_alive = value == b'keep-alive'
+
         self.headers.append((name.decode().casefold(), value.decode()))
 
     def on_headers_complete(self):
@@ -175,7 +180,7 @@ class HttpProtocol(asyncio.Protocol):
         """
         try:
             keep_alive = (
-                self.parser.should_keep_alive() and not self.signal.stopped)
+                self._keep_alive and not self.signal.stopped)
 
             self.transport.write(
                 response.output(


### PR DESCRIPTION
When sending http pipeline requests with wrk:
```
wrk -t10 -c200 -d5s http://127.0.0.1:8080 --latency -s pipeline.lua -- 5
```
An AttributeError Exception has occurred:
```
Task exception was never retrieved
future: <Task finished coro=<Sanic.handle_request() done, defined at /home/luno/.pyenv/versions/sanic-env/lib/python3.6/site-packages/sanic/app.py:348> exception=AttributeError("'NoneType' object has no attribute 'should_keep_alive'",)>
Traceback (most recent call last):
  File "/home/luno/.pyenv/versions/sanic-env/lib/python3.6/site-packages/sanic/app.py", line 424, in handle_request
    response_callback(response)
  File "/home/luno/.pyenv/versions/sanic-env/lib/python3.6/site-packages/sanic/server.py", line 171, in write_response
    self.parser.should_keep_alive() and not self.signal.stopped)
AttributeError: 'NoneType' object has no attribute 'should_keep_alive'
```
This exception is the exact same on the case in sending pipeline request to an [example](http://github.com/MagicStack/vmbench/blob/master/servers/asyncio_http_server.py) of MagicStack using **httptools**.

So I want to try to fix this error by adding a `self._keep_alive` member variable to `HTTPProtocol` class and setting this variable when `on_header(self, name, value)` is invoked.