### PR TITLE
Fix bail_out()

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -254,7 +254,7 @@ class HttpProtocol(asyncio.Protocol):
             self.transport.close()
 
     def bail_out(self, message, from_error=False):
-        if from_error and self.transport.is_closing():
+        if from_error or self.transport.is_closing():
             log.error(
                 ("Transport closed @ {} and exception "
                  "experienced during error handling").format(


### PR DESCRIPTION
When an exception occurs in `write_error()` as shown in the code below,
this prevents that `write_error()` and `bail_out()` is repeated.

```
    def write_error(self, exception):
        try:
            response = self.error_handler.response(self.request, exception)
            version = self.request.version if self.request else '1.1'
            self.transport.write(response.output(version))
            raise Exception()
        except RuntimeError:
            log.error(
                'Connection lost before error written @ {}'.format(
                    self.request.ip if self.request else 'Unknown'))
        except Exception as e:
            self.bail_out(
                "Writing error failed, connection closed {}".format(repr(e)),
                from_error=True)
        finally:
            self.transport.close()
```