### PR TITLE
remove default host attribute in router

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -137,9 +137,6 @@ class Router:
                 for host_ in host:
                     self.add(uri, methods, handler, host_)
                 return
-        else:
-            # default host
-            self.hosts.add('*')
 
         # Dict for faster lookups of if method allowed
         if methods:


### PR DESCRIPTION
Restore speed for no vhosts. In the current implementation the logic [here](https://github.com/r0fls/sanic/blob/0eedde445c043454bf6882b7c910c57bfa335167/sanic/router.py#L280) never happens (because `*` was added to the router hosts). Performance metrics below:

This branch:

```
$ wrk -t 10 -c 100 -d 10 http://localhost:8000
Running 10s test @ http://localhost:8000
  10 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.92ms    1.15ms  15.15ms   66.97%
    Req/Sec     2.56k   317.34     3.19k    54.20%
  255463 requests in 10.02s, 30.21MB read
Requests/sec:  25507.41
Transfer/sec:      3.02MB
```

Current master:

```
$ wrk -t 10 -c 100 -d 10 http://localhost:8000
Running 10s test @ http://localhost:8000
  10 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     5.00ms    1.53ms  13.61ms   62.06%
    Req/Sec     2.01k   187.48     2.48k    69.70%
  200453 requests in 10.03s, 23.70MB read
Requests/sec:  19991.39
Transfer/sec:      2.36MB
```