### PR TITLE
Add Dispatcher Extension to Extensions page in Docs

### DIFF
--- a/docs/sanic/extensions.md
+++ b/docs/sanic/extensions.md
@@ -16,3 +16,4 @@ A list of Sanic extensions created by the community.
 - [Sanic EnvConfig](https://github.com/jamesstidard/sanic-envconfig): Pull environment variables into your sanic config.
 - [Babel](https://github.com/lixxu/sanic-babel): Adds i18n/l10n support to Sanic applications with the help of the
 `Babel` library
+- [Dispatch](https://github.com/ashleysommer/sanic-dispatcher): A dispatcher inspired by `DispatcherMiddleware` in werkzeug. Can act as a Sanic-to-WSGI adapter.


### PR DESCRIPTION
Adds a link to the extension
https://github.com/ashleysommer/sanic-dispatcher
And a very short description
Fixes https://github.com/channelcat/sanic/issues/548