### PR TITLE
Hotfixes tests failing from URL object change

### DIFF
--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -88,4 +88,4 @@ def test_chained_redirect(redirect_app):
     assert request.url.endswith('/1')
     assert response.status == 200
     assert response.text == 'OK'
-    assert response.url.endswith('/3')
+    assert response.url.path.endswith('/3')


### PR DESCRIPTION
aiohttp decided to use yarl for their new URL objects so that they
aren't plain strings anymore which means that this single test fails.
Not a huge change but this should fix the testing suite.