### PR TITLE
I don't think we need to load response body in testing

### DIFF
--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -22,8 +22,8 @@ class SanicTestClient:
                 cookies=cookies, connector=conn) as session:
             async with getattr(
                     session, method.lower())(url, *args, **kwargs) as response:
-                response.text = await response.text()
-                response.body = await response.read()
+                # response.text = await response.text()
+                # response.body = await response.read()
                 return response
 
     def _sanic_endpoint_test(

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -20,10 +20,12 @@ class SanicTestClient:
         conn = aiohttp.TCPConnector(verify_ssl=False)
         async with aiohttp.ClientSession(
                 cookies=cookies, connector=conn) as session:
+            load_body = 'load_body' not in kwargs or kwargs.pop('load_body')
             async with getattr(
                     session, method.lower())(url, *args, **kwargs) as response:
-                # response.text = await response.text()
-                # response.body = await response.read()
+                if load_body:
+                    response.text = await response.text()
+                    response.body = await response.read()
                 return response
 
     def _sanic_endpoint_test(


### PR DESCRIPTION
If you need this, you can call response.text() or response.body() manually.
Is there any idea to resolve the issue #582? 
Just commented the loading operation? 
Or make response.text and response.body as `@property` function to compatible the old versions?