### PR TITLE
Document synchronous response.write in streaming

### DIFF
--- a/docs/sanic/response.md
+++ b/docs/sanic/response.md
@@ -55,8 +55,8 @@ from sanic import response
 @app.route("/streaming")
 async def index(request):
     async def streaming_fn(response):
-        await response.write('foo')
-        await response.write('bar')
+        response.write('foo')
+        response.write('bar')
     return response.stream(streaming_fn, content_type='text/plain')
 ```
 


### PR DESCRIPTION
The Streaming section of the docs [was updated](https://github.com/subyraman/sanic/blob/d8a6d7e02f7628ab4b910e31a6860147c3a2134f/docs/sanic/streaming.md) to make clear that a synchronous write should be used in the callback, but this section was not updated.