### PR TITLE
add sanic-nginx-docker-example to extensions.md

### DIFF
--- a/docs/sanic/extensions.md
+++ b/docs/sanic/extensions.md
@@ -18,3 +18,6 @@ A list of Sanic extensions created by the community.
 `Babel` library
 - [Dispatch](https://github.com/ashleysommer/sanic-dispatcher): A dispatcher inspired by `DispatcherMiddleware` in werkzeug. Can act as a Sanic-to-WSGI adapter.
 - [Sanic-OAuth](https://github.com/Sniedes722/Sanic-OAuth): OAuth Library for connecting to & creating your own token providers.
+- [Sanic-nginx-docker-example](https://github.com/itielshwartz/sanic-nginx-docker-example): Simple and easy to use example of Sanic behined nginx using docker-compose.
+
+

--- a/docs/sanic/extensions.md
+++ b/docs/sanic/extensions.md
@@ -19,5 +19,3 @@ A list of Sanic extensions created by the community.
 - [Dispatch](https://github.com/ashleysommer/sanic-dispatcher): A dispatcher inspired by `DispatcherMiddleware` in werkzeug. Can act as a Sanic-to-WSGI adapter.
 - [Sanic-OAuth](https://github.com/Sniedes722/Sanic-OAuth): OAuth Library for connecting to & creating your own token providers.
 - [Sanic-nginx-docker-example](https://github.com/itielshwartz/sanic-nginx-docker-example): Simple and easy to use example of Sanic behined nginx using docker-compose.
-
-


### PR DESCRIPTION
as discussed in #566 ,I update the extensions file with a full working example of Sanic nginx and docker-compose.