### PR TITLE
Response middleware should be called even if server replies with an error

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -484,12 +484,12 @@ class Sanic:
             # Response Middleware
             # -------------------------------------------- #
             try:
-                response = await self._run_response_middleware(request, response)
+                response = await self._run_response_middleware(request,
+                                                               response)
             except:
                 log.exception(
                     'Exception occured in one of response middleware handlers'
                 )
-
 
         # pass the response to the correct callback
         if isinstance(response, StreamingHTTPResponse):

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -444,17 +444,7 @@ class Sanic:
             # -------------------------------------------- #
 
             request.app = self
-
-            response = False
-            # The if improves speed.  I don't know why
-            if self.request_middleware:
-                for middleware in self.request_middleware:
-                    response = middleware(request)
-                    if isawaitable(response):
-                        response = await response
-                    if response:
-                        break
-
+            response = await self._run_request_middleware(request)
             # No middleware results
             if not response:
                 # -------------------------------------------- #
@@ -472,20 +462,6 @@ class Sanic:
                 response = handler(request, *args, **kwargs)
                 if isawaitable(response):
                     response = await response
-
-            # -------------------------------------------- #
-            # Response Middleware
-            # -------------------------------------------- #
-
-            if self.response_middleware:
-                for middleware in self.response_middleware:
-                    _response = middleware(request, response)
-                    if isawaitable(_response):
-                        _response = await _response
-                    if _response:
-                        response = _response
-                        break
-
         except Exception as e:
             # -------------------------------------------- #
             # Response Generation Failed
@@ -503,6 +479,17 @@ class Sanic:
                 else:
                     response = HTTPResponse(
                         "An error occurred while handling an error")
+        finally:
+            # -------------------------------------------- #
+            # Response Middleware
+            # -------------------------------------------- #
+            try:
+                response = await self._run_response_middleware(request, response)
+            except:
+                log.exception(
+                    'Exception occured in one of response middleware handlers'
+                )
+
 
         # pass the response to the correct callback
         if isinstance(response, StreamingHTTPResponse):
@@ -614,6 +601,28 @@ class Sanic:
             backlog=backlog, run_async=True)
 
         return await serve(**server_settings)
+
+    async def _run_request_middleware(self, request):
+        # The if improves speed.  I don't know why
+        if self.request_middleware:
+            for middleware in self.request_middleware:
+                response = middleware(request)
+                if isawaitable(response):
+                    response = await response
+                if response:
+                    return response
+        return None
+
+    async def _run_response_middleware(self, request, response):
+        if self.response_middleware:
+            for middleware in self.response_middleware:
+                _response = middleware(request, response)
+                if isawaitable(_response):
+                    _response = await _response
+                if _response:
+                    response = _response
+                    break
+        return response
 
     def _helper(self, host="127.0.0.1", port=8000, debug=False,
                 before_start=None, after_start=None, before_stop=None,


### PR DESCRIPTION
I think it would make sense if the response middleware handlers were called even when Sanic replies with an error. Otherwise there's no easy way to build a middleware that monitors status codes.