### PR TITLE
Fix installation on Ubuntu 16.10 #629

### DIFF
--- a/sanic/__init__.py
+++ b/sanic/__init__.py
@@ -1,6 +1,6 @@
 from sanic.app import Sanic
 from sanic.blueprints import Blueprint
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 __all__ = ['Sanic', 'Blueprint']

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,3 @@ except DistutilsPlatformError as exception:
     print("Installing without uJSON or uvLoop")
     setup_kwargs['install_requires'] = requirements
     setup(**setup_kwargs)
-
-# Installation was successful
-print(u"\n\n\U0001F680    "
-      "Sanic version {} installation suceeded.\n".format(version))


### PR DESCRIPTION
Fixes issue #629. 

Printing a unicode string at the end of the `setup.py` script is asking for trouble. It's also redundant: the pip tool itself tells the user whether installation was successful.