### PR TITLE
invariant: body after request is processed must be binary

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -173,8 +173,7 @@ class HttpProtocol(asyncio.Protocol):
         self.request.body.append(body)
 
     def on_message_complete(self):
-        if self.request.body:
-            self.request.body = b''.join(self.request.body)
+        self.request.body = b''.join(self.request.body)
 
         self._request_handler_task = self.loop.create_task(
             self.request_handler(


### PR DESCRIPTION
Body must be of type bytes after request is processed, even if there is no data.
If not, code will fail for example in [here](https://github.com/channelcat/sanic/blob/master/sanic/request.py#L97) if the request does not have any parameters in the body but the content-type is application/x-www-form-urlencoded


