### PR TITLE
Add the killing of children

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -502,6 +502,8 @@ def serve_multiple(server_settings, workers):
     def sig_handler(signal, frame):
         log.info("Received signal {}. Shutting down.".format(
             Signals(signal).name))
+        for process in processes:
+            os.kill(process.pid, SIGINT)
 
     signal_func(SIGINT, lambda s, f: sig_handler(s, f))
     signal_func(SIGTERM, lambda s, f: sig_handler(s, f))


### PR DESCRIPTION
Kills children processes when parent process receives a signal to
shutdown.

Solves for #594