### PR TITLE
Add access.log and error.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ settings.py
 docs/_build/
 docs/_api/
 build/*
+access.log
+error.log


### PR DESCRIPTION
There is `access.log` and `error.log` after test is executed.