### PR TITLE
Expose matched request uri template

### DIFF
--- a/docs/sanic/request_data.md
+++ b/docs/sanic/request_data.md
@@ -94,6 +94,7 @@ The following variables are accessible as properties on `Request` objects:
 - `host`: The host associated with the request: `localhost:8080`
 - `path`: The path of the request: `/posts/1/`
 - `query_string`: The query string of the request: `foo=bar` or a blank string `''`
+- `uri_template`: Template for matching route handler: `/posts/<id>/`
 
 
 ## Accessing values using `get` and `getlist`

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -458,7 +458,8 @@ class Sanic:
                 # -------------------------------------------- #
 
                 # Fetch handler from router
-                handler, args, kwargs = self.router.get(request)
+                handler, args, kwargs, uri = self.router.get(request)
+                request.uri_template = uri
                 if handler is None:
                     raise ServerError(
                         ("'None' was returned while requesting a "

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -38,7 +38,7 @@ class Request(dict):
     __slots__ = (
         'app', 'headers', 'version', 'method', '_cookies', 'transport',
         'body', 'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
-        '_ip', '_parsed_url',
+        '_ip', '_parsed_url', 'uri_template'
     )
 
     def __init__(self, url_bytes, headers, version, method, transport):
@@ -57,6 +57,7 @@ class Request(dict):
         self.parsed_form = None
         self.parsed_files = None
         self.parsed_args = None
+        self.uri_template = None
         self._cookies = None
 
     @property

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -8,7 +8,7 @@ from sanic.views import CompositionView
 
 Route = namedtuple(
     'Route',
-    ['handler', 'methods', 'pattern', 'parameters', 'name'])
+    ['handler', 'methods', 'pattern', 'parameters', 'name', 'uri'])
 Parameter = namedtuple('Parameter', ['name', 'cast'])
 
 REGEX_TYPES = {
@@ -225,7 +225,7 @@ class Router:
 
             route = Route(
                 handler=handler, methods=methods, pattern=pattern,
-                parameters=parameters, name=handler_name)
+                parameters=parameters, name=handler_name, uri=uri)
 
         self.routes_all[uri] = route
         if properties['unhashable']:
@@ -344,4 +344,4 @@ class Router:
         route_handler = route.handler
         if hasattr(route_handler, 'handlers'):
             route_handler = route_handler.handlers[method]
-        return route_handler, [], kwargs
+        return route_handler, [], kwargs, route.uri


### PR DESCRIPTION
Make matching route URI template easily accessible.

It becomes available as `request.uri_template` and looks like `/posts/<id>/`.

It is useful as a key to group metrics by endpoint, for example.

In other frameworks:
- [request.url_rule](http://flask.pocoo.org/docs/0.12/api/#flask.Request.url_rule) in flask
- [request.uri_template](http://falcon.readthedocs.io/en/stable/api/request_and_response.html#Request.uri_template) in falcon