### PR TITLE
Add Request.stream

### DIFF
--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -35,14 +35,29 @@ async def index(request):
 
 Sanic allows you to get request data by stream, as below. When the request ends, `request.stream.get()` returns `None`.
 
-```
+```python
 from sanic import Sanic
 from sanic.views import CompositionView
+from sanic.views import HTTPMethodView
+from sanic.views import stream as stream_decorator
 from sanic.blueprints import Blueprint
 from sanic.response import stream, text
 
 bp = Blueprint('blueprint_request_stream')
 app = Sanic('request_stream', is_request_stream=True)
+
+
+class SimpleView(HTTPMethodView):
+
+    @stream_decorator
+    async def post(self, request):
+        result = ''
+        while True:
+            body = await request.stream.get()
+            if body is None:
+                break
+            result += body.decode('utf-8')
+        return text(result)
 
 
 @app.stream('/stream')
@@ -83,6 +98,7 @@ async def post_handler(request):
     return text(result)
 
 app.blueprint(bp)
+app.add_route(SimpleView.as_view(), '/method_view')
 view = CompositionView()
 view.add(['POST'], post_handler, stream=True)
 app.add_route(view, '/composition_view')

--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -37,6 +37,7 @@ Sanic allows you to get request data by stream, as below. When the request ends,
 
 ```
 from sanic import Sanic
+from sanic.views import CompositionView
 from sanic.blueprints import Blueprint
 from sanic.response import stream, text
 
@@ -71,7 +72,20 @@ async def bp_handler(request):
         result += body.decode('utf-8').replace('1', 'A')
     return text(result)
 
+
+async def post_handler(request):
+    result = ''
+    while True:
+        body = await request.stream.get()
+        if body is None:
+            break
+        result += body.decode('utf-8')
+    return text(result)
+
 app.blueprint(bp)
+view = CompositionView()
+view.add(['POST'], post_handler, stream=True)
+app.add_route(view, '/composition_view')
 
 
 if __name__ == '__main__':

--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -30,3 +30,50 @@ async def index(request):
 
     return stream(stream_from_db)
 ```
+
+## Request Streaming
+
+Sanic allows you to get request data by stream, as below. When the request ends, `request.stream.get()` returns `None`.
+
+```
+from sanic import Sanic
+from sanic.blueprints import Blueprint
+from sanic.response import stream, text
+
+bp = Blueprint('blueprint_request_stream')
+app = Sanic('request_stream', is_request_stream=True)
+
+
+@app.stream('/stream')
+async def handler(request):
+    async def streaming(response):
+        while True:
+            body = await request.stream.get()
+            if body is None:
+                break
+            body = body.decode('utf-8').replace('1', 'A')
+            response.write(body)
+    return stream(streaming)
+
+
+@app.get('/get')
+async def get(request):
+    return text('OK')
+
+
+@bp.stream('/bp_stream')
+async def bp_handler(request):
+    result = ''
+    while True:
+        body = await request.stream.get()
+        if body is None:
+            break
+        result += body.decode('utf-8').replace('1', 'A')
+    return text(result)
+
+app.blueprint(bp)
+
+
+if __name__ == '__main__':
+    app.run(host='127.0.0.1', port=8000)
+```

--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -33,7 +33,7 @@ async def index(request):
 
 ## Request Streaming
 
-Sanic allows you to get request data by stream, as below. When the request ends, `request.stream.get()` returns `None`.
+Sanic allows you to get request data by stream, as below. When the request ends, `request.stream.get()` returns `None`. Only post, put and patch decorator have stream argument.
 
 ```python
 from sanic import Sanic
@@ -60,7 +60,7 @@ class SimpleView(HTTPMethodView):
         return text(result)
 
 
-@app.stream('/stream')
+@app.post('/stream', stream=True)
 async def handler(request):
     async def streaming(response):
         while True:
@@ -72,7 +72,7 @@ async def handler(request):
     return stream(streaming)
 
 
-@bp.stream('/bp_stream')
+@bp.put('/bp_stream', stream=True)
 async def bp_handler(request):
     result = ''
     while True:

--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -1,36 +1,5 @@
 # Streaming
 
-Sanic allows you to stream content to the client with the `stream` method. This method accepts a coroutine callback which is passed a `StreamingHTTPResponse` object that is written to. A simple example is like follows:
-
-```python
-from sanic import Sanic
-from sanic.response import stream
-
-app = Sanic(__name__)
-
-@app.route("/")
-async def test(request):
-    async def sample_streaming_fn(response):
-        response.write('foo,')
-        response.write('bar')
-
-    return stream(sample_streaming_fn, content_type='text/csv')
-```
-
-This is useful in situations where you want to stream content to the client that originates in an external service, like a database. For example, you can stream database records to the client with the asynchronous cursor that `asyncpg` provides:
-
-```python
-@app.route("/")
-async def index(request):
-    async def stream_from_db(response):
-        conn = await asyncpg.connect(database='test')
-        async with conn.transaction():
-            async for record in conn.cursor('SELECT generate_series(0, 10)'):
-                response.write(record[0])
-
-    return stream(stream_from_db)
-```
-
 ## Request Streaming
 
 Sanic allows you to get request data by stream, as below. When the request ends, `request.stream.get()` returns `None`. Only post, put and patch decorator have stream argument.
@@ -101,4 +70,37 @@ app.add_route(view, '/composition_view')
 
 if __name__ == '__main__':
     app.run(host='127.0.0.1', port=8000)
+```
+
+## Response Streaming
+
+Sanic allows you to stream content to the client with the `stream` method. This method accepts a coroutine callback which is passed a `StreamingHTTPResponse` object that is written to. A simple example is like follows:
+
+```python
+from sanic import Sanic
+from sanic.response import stream
+
+app = Sanic(__name__)
+
+@app.route("/")
+async def test(request):
+    async def sample_streaming_fn(response):
+        response.write('foo,')
+        response.write('bar')
+
+    return stream(sample_streaming_fn, content_type='text/csv')
+```
+
+This is useful in situations where you want to stream content to the client that originates in an external service, like a database. For example, you can stream database records to the client with the asynchronous cursor that `asyncpg` provides:
+
+```python
+@app.route("/")
+async def index(request):
+    async def stream_from_db(response):
+        conn = await asyncpg.connect(database='test')
+        async with conn.transaction():
+            async for record in conn.cursor('SELECT generate_series(0, 10)'):
+                response.write(record[0])
+
+    return stream(stream_from_db)
 ```

--- a/docs/sanic/streaming.md
+++ b/docs/sanic/streaming.md
@@ -44,7 +44,7 @@ from sanic.blueprints import Blueprint
 from sanic.response import stream, text
 
 bp = Blueprint('blueprint_request_stream')
-app = Sanic('request_stream', is_request_stream=True)
+app = Sanic('request_stream')
 
 
 class SimpleView(HTTPMethodView):
@@ -70,11 +70,6 @@ async def handler(request):
             body = body.decode('utf-8').replace('1', 'A')
             response.write(body)
     return stream(streaming)
-
-
-@app.get('/get')
-async def get(request):
-    return text('OK')
 
 
 @bp.stream('/bp_stream')

--- a/examples/request_stream/client.py
+++ b/examples/request_stream/client.py
@@ -6,5 +6,5 @@ data = ""
 for i in range(1, 250000):
     data += str(i)
 
-r = requests.post('http://127.0.0.1:8000/method_view', data=data)
+r = requests.post('http://127.0.0.1:8000/stream', data=data)
 print(r.text)

--- a/examples/request_stream/client.py
+++ b/examples/request_stream/client.py
@@ -1,0 +1,10 @@
+import requests
+
+# Warning: This is a heavy process.
+
+data = ""
+for i in range(1, 250000):
+    data += str(i)
+
+r = requests.post('http://127.0.0.1:8000/bp_stream', data=data)
+print(r.text)

--- a/examples/request_stream/client.py
+++ b/examples/request_stream/client.py
@@ -6,5 +6,5 @@ data = ""
 for i in range(1, 250000):
     data += str(i)
 
-r = requests.post('http://127.0.0.1:8000/bp_stream', data=data)
+r = requests.post('http://127.0.0.1:8000/method_view', data=data)
 print(r.text)

--- a/examples/request_stream/server.py
+++ b/examples/request_stream/server.py
@@ -22,7 +22,7 @@ class SimpleView(HTTPMethodView):
         return text(result)
 
 
-@app.stream('/stream')
+@app.post('/stream', stream=True)
 async def handler(request):
     async def streaming(response):
         while True:
@@ -34,7 +34,7 @@ async def handler(request):
     return stream(streaming)
 
 
-@bp.stream('/bp_stream')
+@bp.put('/bp_stream', stream=True)
 async def bp_handler(request):
     result = ''
     while True:

--- a/examples/request_stream/server.py
+++ b/examples/request_stream/server.py
@@ -34,11 +34,6 @@ async def handler(request):
     return stream(streaming)
 
 
-@app.get('/get')
-async def get(request):
-    return text('OK')
-
-
 @bp.stream('/bp_stream')
 async def bp_handler(request):
     result = ''

--- a/examples/request_stream/server.py
+++ b/examples/request_stream/server.py
@@ -1,10 +1,25 @@
 from sanic import Sanic
 from sanic.views import CompositionView
+from sanic.views import HTTPMethodView
+from sanic.views import stream as stream_decorator
 from sanic.blueprints import Blueprint
 from sanic.response import stream, text
 
 bp = Blueprint('blueprint_request_stream')
 app = Sanic('request_stream')
+
+
+class SimpleView(HTTPMethodView):
+
+    @stream_decorator
+    async def post(self, request):
+        result = ''
+        while True:
+            body = await request.stream.get()
+            if body is None:
+                break
+            result += body.decode('utf-8')
+        return text(result)
 
 
 @app.stream('/stream')
@@ -45,6 +60,7 @@ async def post_handler(request):
     return text(result)
 
 app.blueprint(bp)
+app.add_route(SimpleView.as_view(), '/method_view')
 view = CompositionView()
 view.add(['POST'], post_handler, stream=True)
 app.add_route(view, '/composition_view')

--- a/examples/request_stream/server.py
+++ b/examples/request_stream/server.py
@@ -1,4 +1,5 @@
 from sanic import Sanic
+from sanic.views import CompositionView
 from sanic.blueprints import Blueprint
 from sanic.response import stream, text
 
@@ -33,7 +34,20 @@ async def bp_handler(request):
         result += body.decode('utf-8').replace('1', 'A')
     return text(result)
 
+
+async def post_handler(request):
+    result = ''
+    while True:
+        body = await request.stream.get()
+        if body is None:
+            break
+        result += body.decode('utf-8')
+    return text(result)
+
 app.blueprint(bp)
+view = CompositionView()
+view.add(['POST'], post_handler, stream=True)
+app.add_route(view, '/composition_view')
 
 
 if __name__ == '__main__':

--- a/examples/request_stream/server.py
+++ b/examples/request_stream/server.py
@@ -1,0 +1,40 @@
+from sanic import Sanic
+from sanic.blueprints import Blueprint
+from sanic.response import stream, text
+
+bp = Blueprint('blueprint_request_stream')
+app = Sanic('request_stream')
+
+
+@app.stream('/stream')
+async def handler(request):
+    async def streaming(response):
+        while True:
+            body = await request.stream.get()
+            if body is None:
+                break
+            body = body.decode('utf-8').replace('1', 'A')
+            response.write(body)
+    return stream(streaming)
+
+
+@app.get('/get')
+async def get(request):
+    return text('OK')
+
+
+@bp.stream('/bp_stream')
+async def bp_handler(request):
+    result = ''
+    while True:
+        body = await request.stream.get()
+        if body is None:
+            break
+        result += body.decode('utf-8').replace('1', 'A')
+    return text(result)
+
+app.blueprint(bp)
+
+
+if __name__ == '__main__':
+    app.run(host='127.0.0.1', port=8000)

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -144,13 +144,13 @@ class Sanic:
         return self.route(uri, methods=frozenset({"GET"}), host=host,
                           strict_slashes=strict_slashes)
 
-    def post(self, uri, host=None, strict_slashes=False):
+    def post(self, uri, host=None, strict_slashes=False, stream=False):
         return self.route(uri, methods=frozenset({"POST"}), host=host,
-                          strict_slashes=strict_slashes)
+                          strict_slashes=strict_slashes, stream=stream)
 
-    def put(self, uri, host=None, strict_slashes=False):
+    def put(self, uri, host=None, strict_slashes=False, stream=False):
         return self.route(uri, methods=frozenset({"PUT"}), host=host,
-                          strict_slashes=strict_slashes)
+                          strict_slashes=strict_slashes, stream=stream)
 
     def head(self, uri, host=None, strict_slashes=False):
         return self.route(uri, methods=frozenset({"HEAD"}), host=host,
@@ -160,20 +160,13 @@ class Sanic:
         return self.route(uri, methods=frozenset({"OPTIONS"}), host=host,
                           strict_slashes=strict_slashes)
 
-    def patch(self, uri, host=None, strict_slashes=False):
+    def patch(self, uri, host=None, strict_slashes=False, stream=False):
         return self.route(uri, methods=frozenset({"PATCH"}), host=host,
-                          strict_slashes=strict_slashes)
+                          strict_slashes=strict_slashes, stream=stream)
 
     def delete(self, uri, host=None, strict_slashes=False):
         return self.route(uri, methods=frozenset({"DELETE"}), host=host,
                           strict_slashes=strict_slashes)
-
-    def stream(
-            self, uri, methods=frozenset({"POST"}), host=None,
-            strict_slashes=False):
-        return self.route(uri, methods=methods, host=host,
-                          strict_slashes=strict_slashes,
-                          stream=True)
 
     def add_route(self, handler, uri, methods=frozenset({'GET'}), host=None,
                   strict_slashes=False):

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -196,13 +196,13 @@ class Blueprint:
         return self.route(uri, methods=["GET"], host=host,
                           strict_slashes=strict_slashes)
 
-    def post(self, uri, host=None, strict_slashes=False):
+    def post(self, uri, host=None, strict_slashes=False, stream=False):
         return self.route(uri, methods=["POST"], host=host,
-                          strict_slashes=strict_slashes)
+                          strict_slashes=strict_slashes, stream=stream)
 
-    def put(self, uri, host=None, strict_slashes=False):
+    def put(self, uri, host=None, strict_slashes=False, stream=False):
         return self.route(uri, methods=["PUT"], host=host,
-                          strict_slashes=strict_slashes)
+                          strict_slashes=strict_slashes, stream=stream)
 
     def head(self, uri, host=None, strict_slashes=False):
         return self.route(uri, methods=["HEAD"], host=host,
@@ -212,14 +212,10 @@ class Blueprint:
         return self.route(uri, methods=["OPTIONS"], host=host,
                           strict_slashes=strict_slashes)
 
-    def patch(self, uri, host=None, strict_slashes=False):
+    def patch(self, uri, host=None, strict_slashes=False, stream=False):
         return self.route(uri, methods=["PATCH"], host=host,
-                          strict_slashes=strict_slashes)
+                          strict_slashes=strict_slashes, stream=stream)
 
     def delete(self, uri, host=None, strict_slashes=False):
         return self.route(uri, methods=["DELETE"], host=host,
                           strict_slashes=strict_slashes)
-
-    def stream(self, uri, methods=["POST"], host=None, strict_slashes=False):
-        return self.route(uri, methods=methods, host=host,
-                          strict_slashes=strict_slashes, stream=True)

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -5,7 +5,7 @@ from sanic.views import CompositionView
 
 FutureRoute = namedtuple('Route',
                          ['handler', 'uri', 'methods',
-                          'host', 'strict_slashes'])
+                          'host', 'strict_slashes', 'stream'])
 FutureListener = namedtuple('Listener', ['handler', 'uri', 'methods', 'host'])
 FutureMiddleware = namedtuple('Route', ['middleware', 'args', 'kwargs'])
 FutureException = namedtuple('Route', ['handler', 'args', 'kwargs'])
@@ -47,7 +47,8 @@ class Blueprint:
                 uri=uri[1:] if uri.startswith('//') else uri,
                 methods=future.methods,
                 host=future.host or self.host,
-                strict_slashes=future.strict_slashes
+                strict_slashes=future.strict_slashes,
+                stream=future.stream
                 )(future.handler)
 
         for future in self.websocket_routes:
@@ -87,14 +88,15 @@ class Blueprint:
                 app.listener(event)(listener)
 
     def route(self, uri, methods=frozenset({'GET'}), host=None,
-              strict_slashes=False):
+              strict_slashes=False, stream=False):
         """Create a blueprint route from a decorated function.
 
         :param uri: endpoint at which the route will be accessible.
         :param methods: list of acceptable HTTP methods.
         """
         def decorator(handler):
-            route = FutureRoute(handler, uri, methods, host, strict_slashes)
+            route = FutureRoute(
+                handler, uri, methods, host, strict_slashes, stream)
             self.routes.append(route)
             return handler
         return decorator
@@ -131,7 +133,7 @@ class Blueprint:
         :param uri: endpoint at which the route will be accessible.
         """
         def decorator(handler):
-            route = FutureRoute(handler, uri, [], host, strict_slashes)
+            route = FutureRoute(handler, uri, [], host, strict_slashes, False)
             self.websocket_routes.append(route)
             return handler
         return decorator
@@ -217,3 +219,7 @@ class Blueprint:
     def delete(self, uri, host=None, strict_slashes=False):
         return self.route(uri, methods=["DELETE"], host=host,
                           strict_slashes=strict_slashes)
+
+    def stream(self, uri, methods=["POST"], host=None, strict_slashes=False):
+        return self.route(uri, methods=methods, host=host,
+                          strict_slashes=strict_slashes, stream=True)

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -38,7 +38,7 @@ class Request(dict):
     __slots__ = (
         'app', 'headers', 'version', 'method', '_cookies', 'transport',
         'body', 'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
-        '_ip', '_parsed_url', 'uri_template'
+        '_ip', '_parsed_url', 'uri_template', 'stream'
     )
 
     def __init__(self, url_bytes, headers, version, method, transport):
@@ -59,6 +59,7 @@ class Request(dict):
         self.parsed_args = None
         self.uri_template = None
         self._cookies = None
+        self.stream = None
 
     @property
     def json(self):

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -355,4 +355,4 @@ class Router:
         if (hasattr(handler, 'view_class') and
                 hasattr(handler.view_class, request.method.lower())):
             handler = getattr(handler.view_class, request.method.lower())
-        return hasattr(handler, 'is_stream') and handler.is_stream
+        return hasattr(handler, 'is_stream')

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -352,4 +352,7 @@ class Router:
         :return: bool
         """
         handler = self.get(request)[0]
+        if (hasattr(handler, 'view_class') and
+                hasattr(handler.view_class, request.method.lower())):
+            handler = getattr(handler.view_class, request.method.lower())
         return hasattr(handler, 'is_stream') and handler.is_stream

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -352,4 +352,4 @@ class Router:
         :return: bool
         """
         handler = self.get(request)[0]
-        return handler.is_stream
+        return hasattr(handler, 'is_stream') and handler.is_stream

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -345,3 +345,11 @@ class Router:
         if hasattr(route_handler, 'handlers'):
             route_handler = route_handler.handlers[method]
         return route_handler, [], kwargs, route.uri
+
+    def is_stream_handler(self, request):
+        """ Handler for request is stream or not.
+        :param request: Request object
+        :return: bool
+        """
+        handler = self.get(request)[0]
+        return handler.is_stream

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -64,22 +64,24 @@ class HttpProtocol(asyncio.Protocol):
         'parser', 'request', 'url', 'headers',
         # request config
         'request_handler', 'request_timeout', 'request_max_size',
-        'request_class',
+        'request_class', 'is_request_stream', 'router',
         # enable or disable access log / error log purpose
         'has_log',
         # connection management
-        '_total_request_size', '_timeout_handler', '_last_communication_time')
+        '_total_request_size', '_timeout_handler', '_last_communication_time',
+        '_is_stream_handler')
 
     def __init__(self, *, loop, request_handler, error_handler,
                  signal=Signal(), connections=set(), request_timeout=60,
                  request_max_size=None, request_class=None, has_log=True,
-                 keep_alive=True):
+                 keep_alive=True, is_request_stream=False, router=None):
         self.loop = loop
         self.transport = None
         self.request = None
         self.parser = None
         self.url = None
         self.headers = None
+        self.router = router
         self.signal = signal
         self.has_log = has_log
         self.connections = connections
@@ -88,10 +90,13 @@ class HttpProtocol(asyncio.Protocol):
         self.request_timeout = request_timeout
         self.request_max_size = request_max_size
         self.request_class = request_class or Request
+        self.is_request_stream = is_request_stream
+        self._is_stream_handler = False
         self._total_request_size = 0
         self._timeout_handler = None
         self._last_request_time = None
         self._request_handler_task = None
+        self._request_stream_task = None
         self._keep_alive = keep_alive
 
     @property
@@ -123,6 +128,8 @@ class HttpProtocol(asyncio.Protocol):
             self._timeout_handler = (
                 self.loop.call_later(time_left, self.connection_timeout))
         else:
+            if self._request_stream_task:
+                self._request_stream_task.cancel()
             if self._request_handler_task:
                 self._request_handler_task.cancel()
             exception = RequestTimeout('Request Timeout')
@@ -171,13 +178,29 @@ class HttpProtocol(asyncio.Protocol):
             method=self.parser.get_method().decode(),
             transport=self.transport
         )
+        if self.is_request_stream:
+            self._is_stream_handler = self.router.is_stream_handler(
+                self.request)
+            if self._is_stream_handler:
+                self.request.stream = asyncio.Queue()
+                self.execute_request_handler()
 
     def on_body(self, body):
+        if self.is_request_stream and self._is_stream_handler:
+            self._request_stream_task = self.loop.create_task(
+                self.request.stream.put(body))
+            return
         self.request.body.append(body)
 
     def on_message_complete(self):
+        if self.is_request_stream and self._is_stream_handler:
+            self._request_stream_task = self.loop.create_task(
+                self.request.stream.put(None))
+            return
         self.request.body = b''.join(self.request.body)
+        self.execute_request_handler()
 
+    def execute_request_handler(self):
         self._request_handler_task = self.loop.create_task(
             self.request_handler(
                 self.request,
@@ -317,7 +340,9 @@ class HttpProtocol(asyncio.Protocol):
         self.url = None
         self.headers = None
         self._request_handler_task = None
+        self._request_stream_task = None
         self._total_request_size = 0
+        self._is_stream_handler = False
 
     def close_if_idle(self):
         """Close the connection if a request is not being sent or received
@@ -359,7 +384,8 @@ def serve(host, port, request_handler, error_handler, before_start=None,
           request_timeout=60, ssl=None, sock=None, request_max_size=None,
           reuse_port=False, loop=None, protocol=HttpProtocol, backlog=100,
           register_sys_signals=True, run_async=False, connections=None,
-          signal=Signal(), request_class=None, has_log=True, keep_alive=True):
+          signal=Signal(), request_class=None, has_log=True, keep_alive=True,
+          is_request_stream=False, router=None):
     """Start asynchronous HTTP Server on an individual process.
 
     :param host: Address to host on
@@ -386,6 +412,8 @@ def serve(host, port, request_handler, error_handler, before_start=None,
     :param protocol: subclass of asyncio protocol class
     :param request_class: Request class to use
     :param has_log: disable/enable access log and error log
+    :param is_request_stream: disable/enable Request.stream
+    :param router: Router object
     :return: Nothing
     """
     if not run_async:
@@ -410,6 +438,8 @@ def serve(host, port, request_handler, error_handler, before_start=None,
         request_class=request_class,
         has_log=has_log,
         keep_alive=keep_alive,
+        is_request_stream=is_request_stream,
+        router=router,
     )
 
     server_coroutine = loop.create_server(

--- a/sanic/views.py
+++ b/sanic/views.py
@@ -89,7 +89,8 @@ class CompositionView:
         self.handlers = {}
 
     def add(self, methods, handler, stream=False):
-        handler.is_stream = stream
+        if stream:
+            handler.is_stream = stream
         for method in methods:
             if method not in HTTP_METHODS:
                 raise InvalidUsage(

--- a/sanic/views.py
+++ b/sanic/views.py
@@ -83,7 +83,8 @@ class CompositionView:
     def __init__(self):
         self.handlers = {}
 
-    def add(self, methods, handler):
+    def add(self, methods, handler, stream=False):
+        handler.is_stream = stream
         for method in methods:
             if method not in HTTP_METHODS:
                 raise InvalidUsage(

--- a/sanic/views.py
+++ b/sanic/views.py
@@ -64,6 +64,11 @@ class HTTPMethodView:
         return view
 
 
+def stream(func):
+    func.is_stream = True
+    return func
+
+
 class CompositionView:
     """Simple method-function mapped view for the sanic.
     You can add handler functions to methods (get, post, put, patch, delete)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -17,10 +17,12 @@ def test_bp():
 
     @bp.route('/')
     def handler(request):
+        assert request.stream is None
         return text('Hello')
 
     app.blueprint(bp)
     request, response = app.test_client.get('/')
+    assert app.is_request_stream is False
 
     assert response.text == 'Hello'
 

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -17,7 +17,6 @@ def test_bp():
 
     @bp.route('/')
     def handler(request):
-        assert request.stream is None
         return text('Hello')
 
     app.blueprint(bp)
@@ -270,37 +269,47 @@ def test_bp_shorthand():
 
     @blueprint.get('/get')
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @blueprint.put('/put')
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @blueprint.post('/post')
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @blueprint.head('/head')
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @blueprint.options('/options')
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @blueprint.patch('/patch')
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @blueprint.delete('/delete')
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @blueprint.websocket('/ws')
     async def handler(request, ws):
+        assert request.stream is None
         ev.set()
 
     app.blueprint(blueprint)
+
+    assert app.is_request_stream is False
 
     request, response = app.test_client.get('/get')
     assert response.text == 'OK'

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -1,0 +1,50 @@
+from sanic import Sanic
+from sanic.blueprints import Blueprint
+from sanic.response import stream, text
+
+bp = Blueprint('test_blueprint_request_stream')
+app = Sanic('test_request_stream')
+
+
+@app.stream('/stream')
+async def handler(request):
+    async def streaming(response):
+        while True:
+            body = await request.stream.get()
+            if body is None:
+                break
+            response.write(body.decode('utf-8'))
+    return stream(streaming)
+
+
+@app.get('/get')
+async def get(request):
+    return text('OK')
+
+
+@bp.stream('/bp_stream')
+async def bp_handler(request):
+    result = ''
+    while True:
+        body = await request.stream.get()
+        if body is None:
+            break
+        result += body.decode('utf-8')
+    return text(result)
+
+app.blueprint(bp)
+
+
+def test_request_stream():
+    data = "abc" * 100000
+    request, response = app.test_client.post('/stream', data=data)
+    assert response.status == 200
+    assert response.text == data
+
+    request, response = app.test_client.get('/get')
+    assert response.status == 200
+    assert response.text == 'OK'
+
+    request, response = app.test_client.post('/bp_stream', data=data)
+    assert response.status == 200
+    assert response.text == data

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -1,9 +1,17 @@
 from sanic import Sanic
 from sanic.blueprints import Blueprint
+from sanic.views import CompositionView
+from sanic.views import HTTPMethodView
 from sanic.response import stream, text
 
 bp = Blueprint('test_blueprint_request_stream')
 app = Sanic('test_request_stream')
+
+
+class SimpleView(HTTPMethodView):
+
+    def get(self, request):
+        return text('OK')
 
 
 @app.stream('/stream')
@@ -32,18 +40,54 @@ async def bp_handler(request):
         result += body.decode('utf-8')
     return text(result)
 
+
+def get_handler(request):
+    return text('OK')
+
+
+async def post_handler(request):
+    result = ''
+    while True:
+        body = await request.stream.get()
+        if body is None:
+            break
+        result += body.decode('utf-8')
+    return text(result)
+
+
+app.add_route(SimpleView.as_view(), '/method_view')
+
+view = CompositionView()
+view.add(['GET'], get_handler)
+view.add(['POST'], post_handler, stream=True)
+
 app.blueprint(bp)
+
+app.add_route(view, '/composition_view')
 
 
 def test_request_stream():
     data = "abc" * 100000
-    request, response = app.test_client.post('/stream', data=data)
+
+    request, response = app.test_client.get('/method_view')
+    assert response.status == 200
+    assert response.text == 'OK'
+
+    request, response = app.test_client.get('/composition_view')
+    assert response.status == 200
+    assert response.text == 'OK'
+
+    request, response = app.test_client.post('/composition_view', data=data)
     assert response.status == 200
     assert response.text == data
 
     request, response = app.test_client.get('/get')
     assert response.status == 200
     assert response.text == 'OK'
+
+    request, response = app.test_client.post('/stream', data=data)
+    assert response.status == 200
+    assert response.text == data
 
     request, response = app.test_client.post('/bp_stream', data=data)
     assert response.status == 200

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -1,3 +1,4 @@
+import asyncio
 from sanic import Sanic
 from sanic.blueprints import Blueprint
 from sanic.views import CompositionView
@@ -5,17 +6,86 @@ from sanic.views import HTTPMethodView
 from sanic.views import stream as stream_decorator
 from sanic.response import stream, text
 
-bp = Blueprint('test_blueprint_request_stream')
-app = Sanic('test_request_stream')
+data = "abc" * 100000
 
 
-class SimpleView(HTTPMethodView):
+def test_request_stream_method_view():
+    '''for self.is_request_stream = True'''
 
-    def get(self, request):
+    app = Sanic('test_request_stream_method_view')
+
+    class SimpleView(HTTPMethodView):
+
+        def get(self, request):
+            assert request.stream is None
+            return text('OK')
+
+        @stream_decorator
+        async def post(self, request):
+            assert isinstance(request.stream, asyncio.Queue)
+            result = ''
+            while True:
+                body = await request.stream.get()
+                if body is None:
+                    break
+                result += body.decode('utf-8')
+            return text(result)
+
+    app.add_route(SimpleView.as_view(), '/method_view')
+
+    assert app.is_request_stream is True
+
+    request, response = app.test_client.get('/method_view')
+    assert response.status == 200
+    assert response.text == 'OK'
+
+    request, response = app.test_client.post('/method_view', data=data)
+    assert response.status == 200
+    assert response.text == data
+
+
+def test_request_stream_app():
+    '''for self.is_request_stream = True'''
+
+    app = Sanic('test_request_stream_app')
+
+    @app.stream('/stream')
+    async def handler(request):
+        assert isinstance(request.stream, asyncio.Queue)
+
+        async def streaming(response):
+            while True:
+                body = await request.stream.get()
+                if body is None:
+                    break
+                response.write(body.decode('utf-8'))
+        return stream(streaming)
+
+    @app.get('/get')
+    async def get(request):
+        assert request.stream is None
         return text('OK')
 
-    @stream_decorator
-    async def post(self, request):
+    assert app.is_request_stream is True
+
+    request, response = app.test_client.get('/get')
+    assert response.status == 200
+    assert response.text == 'OK'
+
+    request, response = app.test_client.post('/stream', data=data)
+    assert response.status == 200
+    assert response.text == data
+
+
+def test_request_stream_blueprint():
+    '''for self.is_request_stream = True'''
+
+    app = Sanic('test_request_stream_blueprint')
+    bp = Blueprint('test_blueprint_request_stream_blueprint')
+
+    @bp.stream('/bp_stream')
+    async def bp_stream(request):
+        assert isinstance(request.stream, asyncio.Queue)
         result = ''
         while True:
             body = await request.stream.get()
@@ -24,66 +94,140 @@ class SimpleView(HTTPMethodView):
             result += body.decode('utf-8')
         return text(result)
 
+    @bp.get('/bp_get')
+    async def bp_get(request):
+        assert request.stream is None
+        return text('OK')
 
-@app.stream('/stream')
-async def handler(request):
-    async def streaming(response):
+    app.blueprint(bp)
+
+    assert app.is_request_stream is True
+
+    request, response = app.test_client.get('/bp_get')
+    assert response.status == 200
+    assert response.text == 'OK'
+
+    request, response = app.test_client.post('/bp_stream', data=data)
+    assert response.status == 200
+    assert response.text == data
+
+
+def test_request_stream_composition_view():
+    '''for self.is_request_stream = True'''
+
+    app = Sanic('test_request_stream__composition_view')
+
+    def get_handler(request):
+        assert request.stream is None
+        return text('OK')
+
+    async def post_handler(request):
+        assert isinstance(request.stream, asyncio.Queue)
+        result = ''
         while True:
             body = await request.stream.get()
             if body is None:
                 break
-            response.write(body.decode('utf-8'))
-    return stream(streaming)
+            result += body.decode('utf-8')
+        return text(result)
 
+    view = CompositionView()
+    view.add(['GET'], get_handler)
+    view.add(['POST'], post_handler, stream=True)
+    app.add_route(view, '/composition_view')
 
-@app.get('/get')
-async def get(request):
-    return text('OK')
+    assert app.is_request_stream is True
 
+    request, response = app.test_client.get('/composition_view')
+    assert response.status == 200
+    assert response.text == 'OK'
 
-@bp.stream('/bp_stream')
-async def bp_stream(request):
-    result = ''
-    while True:
-        body = await request.stream.get()
-        if body is None:
-            break
-        result += body.decode('utf-8')
-    return text(result)
-
-
-@bp.get('/bp_get')
-async def bp_get(request):
-    return text('OK')
-
-
-def get_handler(request):
-    return text('OK')
-
-
-async def post_handler(request):
-    result = ''
-    while True:
-        body = await request.stream.get()
-        if body is None:
-            break
-        result += body.decode('utf-8')
-    return text(result)
-
-
-app.add_route(SimpleView.as_view(), '/method_view')
-
-view = CompositionView()
-view.add(['GET'], get_handler)
-view.add(['POST'], post_handler, stream=True)
-
-app.blueprint(bp)
-
-app.add_route(view, '/composition_view')
+    request, response = app.test_client.post('/composition_view', data=data)
+    assert response.status == 200
+    assert response.text == data
 
 
 def test_request_stream():
-    data = "abc" * 100000
+    '''test for complex application'''
+
+    bp = Blueprint('test_blueprint_request_stream')
+    app = Sanic('test_request_stream')
+
+    class SimpleView(HTTPMethodView):
+
+        def get(self, request):
+            assert request.stream is None
+            return text('OK')
+
+        @stream_decorator
+        async def post(self, request):
+            assert isinstance(request.stream, asyncio.Queue)
+            result = ''
+            while True:
+                body = await request.stream.get()
+                if body is None:
+                    break
+                result += body.decode('utf-8')
+            return text(result)
+
+    @app.stream('/stream')
+    async def handler(request):
+        assert isinstance(request.stream, asyncio.Queue)
+
+        async def streaming(response):
+            while True:
+                body = await request.stream.get()
+                if body is None:
+                    break
+                response.write(body.decode('utf-8'))
+        return stream(streaming)
+
+    @app.get('/get')
+    async def get(request):
+        assert request.stream is None
+        return text('OK')
+
+    @bp.stream('/bp_stream')
+    async def bp_stream(request):
+        assert isinstance(request.stream, asyncio.Queue)
+        result = ''
+        while True:
+            body = await request.stream.get()
+            if body is None:
+                break
+            result += body.decode('utf-8')
+        return text(result)
+
+    @bp.get('/bp_get')
+    async def bp_get(request):
+        assert request.stream is None
+        return text('OK')
+
+    def get_handler(request):
+        assert request.stream is None
+        return text('OK')
+
+    async def post_handler(request):
+        assert isinstance(request.stream, asyncio.Queue)
+        result = ''
+        while True:
+            body = await request.stream.get()
+            if body is None:
+                break
+            result += body.decode('utf-8')
+        return text(result)
+
+    app.add_route(SimpleView.as_view(), '/method_view')
+
+    view = CompositionView()
+    view.add(['GET'], get_handler)
+    view.add(['POST'], post_handler, stream=True)
+
+    app.blueprint(bp)
+
+    app.add_route(view, '/composition_view')
+
+    assert app.is_request_stream is True
 
     request, response = app.test_client.get('/method_view')
     assert response.status == 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -28,11 +28,14 @@ def test_route_strict_slash():
 
     @app.get('/get', strict_slashes=True)
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     @app.post('/post/', strict_slashes=True)
     def handler(request):
         return text('OK')
+
+    assert app.is_request_stream is False
 
     request, response = app.test_client.get('/get')
     assert response.text == 'OK'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -33,6 +33,7 @@ def test_route_strict_slash():
 
     @app.post('/post/', strict_slashes=True)
     def handler(request):
+        assert request.stream is None
         return text('OK')
 
     assert app.is_request_stream is False
@@ -80,7 +81,10 @@ def test_shorthand_routes_put():
 
     @app.put('/put')
     def handler(request):
+        assert request.stream is None
         return text('OK')
+
+    assert app.is_request_stream is False
 
     request, response = app.test_client.put('/put')
     assert response.text == 'OK'
@@ -88,12 +92,31 @@ def test_shorthand_routes_put():
     request, response = app.test_client.get('/put')
     assert response.status == 405
 
+def test_shorthand_routes_delete():
+    app = Sanic('test_shorhand_routes_delete')
+
+    @app.delete('/delete')
+    def handler(request):
+        assert request.stream is None
+        return text('OK')
+
+    assert app.is_request_stream is False
+
+    request, response = app.test_client.delete('/delete')
+    assert response.text == 'OK'
+
+    request, response = app.test_client.get('/delete')
+    assert response.status == 405
+
 def test_shorthand_routes_patch():
     app = Sanic('test_shorhand_routes_patch')
 
     @app.patch('/patch')
     def handler(request):
+        assert request.stream is None
         return text('OK')
+
+    assert app.is_request_stream is False
 
     request, response = app.test_client.patch('/patch')
     assert response.text == 'OK'
@@ -106,7 +129,10 @@ def test_shorthand_routes_head():
 
     @app.head('/head')
     def handler(request):
+        assert request.stream is None
         return text('OK')
+
+    assert app.is_request_stream is False
 
     request, response = app.test_client.head('/head')
     assert response.status == 200
@@ -119,7 +145,10 @@ def test_shorthand_routes_options():
 
     @app.options('/options')
     def handler(request):
+        assert request.stream is None
         return text('OK')
+
+    assert app.is_request_stream is False
 
     request, response = app.test_client.options('/options')
     assert response.status == 200


### PR DESCRIPTION
This adds `Request.stream` and `stream decorator`, as below.

```python
from sanic import Sanic
from sanic.views import CompositionView
from sanic.views import HTTPMethodView
from sanic.views import stream as stream_decorator
from sanic.blueprints import Blueprint
from sanic.response import stream, text

bp = Blueprint('blueprint_request_stream')
app = Sanic('request_stream')


class SimpleView(HTTPMethodView):

    @stream_decorator
    async def post(self, request):
        result = ''
        while True:
            body = await request.stream.get()
            if body is None:
                break
            result += body.decode('utf-8')
        return text(result)


@app.post('/stream', stream=True)
async def handler(request):
    async def streaming(response):
        while True:
            body = await request.stream.get()
            if body is None:
                break
            body = body.decode('utf-8').replace('1', 'A')
            response.write(body)
    return stream(streaming)


@bp.put('/bp_stream', stream=True)
async def bp_handler(request):
    result = ''
    while True:
        body = await request.stream.get()
        if body is None:
            break
        result += body.decode('utf-8').replace('1', 'A')
    return text(result)


async def post_handler(request):
    result = ''
    while True:
        body = await request.stream.get()
        if body is None:
            break
        result += body.decode('utf-8')
    return text(result)

app.blueprint(bp)
app.add_route(SimpleView.as_view(), '/method_view')
view = CompositionView()
view.add(['POST'], post_handler, stream=True)
app.add_route(view, '/composition_view')


if __name__ == '__main__':
    app.run(host='127.0.0.1', port=8000)
```