### PR TITLE
exception_base decorator

### DIFF
--- a/docs/sanic/exceptions.md
+++ b/docs/sanic/exceptions.md
@@ -43,3 +43,11 @@ Some of the most useful exceptions are presented below:
   usually occurs if there is an exception raised in user code.
 
 See the `sanic.exceptions` module for the full list of exceptions to throw.
+
+You can also use `exceptions_base`, it can catch the exception just like
+normal catching. It can be used for catching all unexpected error and eliminate
+the risk that server information being stolen by attackers/
+
+@app.exception_base(Exception)
+def catch_everything(request, exception):
+	return text( "Server Error!",500)

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -290,7 +290,7 @@ class Sanic:
             return handler
 
         return response
-		
+
     # Decorator
     def middleware(self, middleware_or_request):
         """Decorate and register middleware to be called before a request.

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -273,6 +273,25 @@ class Sanic:
         return response
 
     # Decorator
+    def exception_base(self, *exceptions):
+        """Decorate a function to be registered as a handler for exceptions
+
+        :param exceptions: exceptions
+        :return: decorated function
+        """
+
+        def response(handler):
+            for exception in exceptions:
+                if isinstance(exception, (tuple, list)):
+                    for e in exception:
+                        self.error_handler.add_base(e, handler)
+                else:
+                    self.error_handler.add_base(exception, handler)
+            return handler
+
+        return response
+		
+    # Decorator
     def middleware(self, middleware_or_request):
         """Decorate and register middleware to be called before a request.
         Can either be called as @app.middleware or @app.middleware('request')

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -18,6 +18,7 @@ from sanic.response import text, html
 
 class ErrorHandler:
     handlers = None
+    handlers_base = None
     cached_handlers = None
     _missing = object()
 

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -57,7 +57,7 @@ class ErrorHandler:
 
     def add(self, exception, handler):
         self.handlers.append((exception, handler))
-		
+
     def add_base(self, exception, handler):
         self.handlers_base.append((exception, handler))
 
@@ -71,12 +71,12 @@ class ErrorHandler:
 
             for exception_class, handler in self.handlers_base:
                 try:
-                    raise 
+                    raise
                 except exception_class:
                     return handler
                 except Exception:
                     pass
-			
+
             self.cached_handlers[type(exception)] = None
             handler = None
         return handler

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -23,6 +23,7 @@ class ErrorHandler:
 
     def __init__(self):
         self.handlers = []
+        self.handlers_base = []
         self.cached_handlers = {}
         self.debug = False
 
@@ -55,6 +56,9 @@ class ErrorHandler:
 
     def add(self, exception, handler):
         self.handlers.append((exception, handler))
+		
+    def add_base(self, exception, handler):
+        self.handlers_base.append((exception, handler))
 
     def lookup(self, exception):
         handler = self.cached_handlers.get(exception, self._missing)
@@ -63,6 +67,15 @@ class ErrorHandler:
                 if isinstance(exception, exception_class):
                     self.cached_handlers[type(exception)] = handler
                     return handler
+
+            for exception_class, handler in self.handlers_base:
+                try:
+                    raise 
+                except exception_class:
+                    return handler
+                except Exception:
+                    pass
+			
             self.cached_handlers[type(exception)] = None
             handler = None
         return handler

--- a/tests/test_exceptions_handler.py
+++ b/tests/test_exceptions_handler.py
@@ -43,12 +43,25 @@ def handler_6(request, arg):
         raise e from ValueError("{}".format(arg))
     return text(foo)
 
+@exception_handler_app.route('/7')
+def handler_7(request):
+    # raise an IndexError
+    a = [1,2,3]
+    return text( a[3] )
 
 @exception_handler_app.exception(NotFound, ServerError)
 def handler_exception(request, exception):
     return text("OK")
+    
+@exception_handler_app.exception(NotFound, ServerError)
+def handler_exception(request, exception):
+    return text("OK")
 
-
+@exception_handler_app.exception_base( LookupError )
+def handler_exception(request, exception):
+    # LookupError can catch IndexError
+    return text("Caught by LookupError")
+    
 def test_invalid_usage_exception_handler():
     request, response = exception_handler_app.test_client.get('/1')
     assert response.status == 400
@@ -112,6 +125,11 @@ def test_chained_exception_handler():
         "ZeroDivisionError: division by zero "
         "while handling path /6/0") == summary_text
 
+def test_chained_exception_base_handler():
+    request, response = exception_handler_app.test_client.get(
+        '/7', debug=True)
+    assert response.status == 200
+    assert response.body == b'Caught by LookupError'
 
 def test_exception_handler_lookup():
     class CustomError(Exception):


### PR DESCRIPTION
I added a app.exception_base as an alternative to app.exception, the differences is that exception_base use a real try except syntax to test is a error is a subclass of another error. It can let user take better care of different kinds of exceptions. 
The main reason I add this is that sanic expose the error messages very clearly to the client side, I think we need an approach to handle unexpected error and keep server information away from attackers.