### PR TITLE
Remove timedRotatingFile log config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@ settings.py
 docs/_build/
 docs/_api/
 build/*
-access.log
-error.log

--- a/docs/sanic/logging.md
+++ b/docs/sanic/logging.md
@@ -76,13 +76,6 @@ By default, log_config parameter is set to use sanic.config.LOGGING dictionary f
   (Notice that in Docker you have to enable everything by yourself)
 
 
-- accessTimedRotatingFile (using [logging.handlers.TimedRotatingFileHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.TimedRotatingFileHandler))<br>
-  For requests information logging to file with daily rotation support.
-
-
-- errorTimedRotatingFile (using [logging.handlers.TimedRotatingFileHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.TimedRotatingFileHandler))<br>
-  For error message and traceback logging to file with daily rotation support.
-
 And `filters`:
 
 - accessFilter (using sanic.log.DefaultFilter)<br>

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -77,24 +77,6 @@ LOGGING = {
             'filters': ['errorFilter'],
             'formatter': 'simple'
         },
-        'accessTimedRotatingFile': {
-            'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filters': ['accessFilter'],
-            'formatter': 'access',
-            'when': 'D',
-            'interval': 1,
-            'backupCount': 7,
-            'filename': 'access.log'
-        },
-        'errorTimedRotatingFile': {
-            'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filters': ['errorFilter'],
-            'when': 'D',
-            'interval': 1,
-            'backupCount': 7,
-            'filename': 'error.log',
-            'formatter': 'simple'
-        }
     },
     'loggers': {
         'sanic': {


### PR DESCRIPTION
It will create two files in user's home directory. It's ok when you deploy one sanic application, just a little annoying if you don't use file logs. But when you deploy many sanic application and don't use file logs they all share the same two file's in home directory, it's bad.

If one wants to log to file, provide that logging configuration himself.