### PR TITLE
add support for adding middlewares to a specific handler

### DIFF
--- a/docs/sanic/middleware.md
+++ b/docs/sanic/middleware.md
@@ -26,6 +26,32 @@ async def print_on_response(request, response):
 	print("I print when a response is returned by the server")
 ```
 
+Besides above two types of middleware declared using the `@app.middleware` decorator,
+you can aslo mount middleware functions to a specific handler as `'request'` or `'response'`
+middleware. Request middleware receives exactly the same parameters as your handler function.
+Response middleware receives an additional `'response'` parameter comparing to Request middleware.
+
+```python
+async def authenticate(request, lock_id):
+    if lock_id != request.headers['key_id']:
+        return response.json(
+            status=403,
+            headers={"Authentication": "Failed"}
+        )
+
+async def say_goodby(request, respone, lock_id):
+    respone.headers.update({"Add-Header": "May the force be with you"})
+
+@app.route('/lock/<lock_id>', middleware={"request": authenticate, "response": say_goodbye})
+async def handler(request, lock_id):
+    return response.json({"message": "welcome back"})
+```
+
+In above example, you can also pass in multi Request or Response middlewares
+as a list of functions to the middleware keyword argument in route decorator.
+They will be excuted in order if no early response happens. Please see below
+`'Responding early'` section for detail.
+
 ## Modifying the request or response
 
 Middleware can modify the request or response parameter it is given, *as long
@@ -68,6 +94,9 @@ async def halt_request(request):
 async def halt_response(request, response):
 	return text('I halted the response')
 ```
+
+Above description also works for middleware functions that mounted on a specific handler
+using the route decorate.
 
 ## Listeners
 

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -128,7 +128,7 @@ class Sanic:
             # attach middleware to specific handler
             if middleware:
                 for r in ('request', 'response'):
-                    mid = middleware[r]
+                    mid = middleware.setdefault(r, None)
                     if mid:
                         if callable(mid):
                             vars(handler)["_"+r+"_middleware"] = mid,
@@ -139,6 +139,8 @@ class Sanic:
                                 "Middleware mounted on a handler should " 
                                 "be a function or a sequence of functions"
                             )
+                    else:
+                        vars(handler)["_"+r+"_middleware"] = ()
 
             self.router.add(uri=uri, methods=methods, handler=handler,
                             host=host, strict_slashes=strict_slashes)

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -12,7 +12,8 @@ from ssl import create_default_context, Purpose
 
 from sanic.config import Config, LOGGING
 from sanic.constants import HTTP_METHODS
-from sanic.exceptions import ServerError, URLBuildError, SanicException, MiddlewareTypeError
+from sanic.exceptions import ServerError, URLBuildError, SanicException,\
+     MiddlewareTypeError
 from sanic.handlers import ErrorHandler
 from sanic.log import log
 from sanic.response import HTTPResponse, StreamingHTTPResponse
@@ -136,7 +137,7 @@ class Sanic:
                             vars(handler)['_'+r+'_middleware'] = tuple(mid)
                         else:
                             raise MiddlewareTypeError(
-                                "Middleware mounted on a handler should " 
+                                "Middleware mounted on a handler should "
                                 "be a function or a sequence of functions"
                             )
 
@@ -481,8 +482,10 @@ class Sanic:
                 if hasattr(handler, "_request_middleware"):
                     mounted_request_middleware = handler._request_middleware
                     if mounted_request_middleware:
-                        response = await self._handle_mounted_request_middleware(
-                            mounted_request_middleware, request, *args, **kwargs
+                        response = \
+                        await self._handle_mounted_request_middleware(
+                            mounted_request_middleware, request,
+                            *args, **kwargs
                         )
                 # No mounted request middleware result
                 if not response:
@@ -498,10 +501,11 @@ class Sanic:
                 if hasattr(handler, "_response_middleware"):
                     mounted_response_middleware = handler._response_middleware
                     if mounted_response_middleware:
-                        response = await self._handle_mounted_response_middleware(
-                            mounted_response_middleware, request, response, *args, **kwargs
+                        response = \
+                        await self._handle_mounted_response_middleware(
+                            mounted_response_middleware, request, response,
+                            *args, **kwargs
                         )
-
 
         except Exception as e:
             # -------------------------------------------- #
@@ -658,7 +662,8 @@ class Sanic:
                     break
         return response
 
-    async def _handle_mounted_request_middleware(self, middleware, request, *args, **kwargs):
+    async def _handle_mounted_request_middleware(self, middleware, request,
+                                                 *args, **kwargs):
         for mid in middleware:
             response = mid(request, *args, **kwargs)
             if isawaitable(response):
@@ -667,7 +672,8 @@ class Sanic:
                 break
         return response
 
-    async def _handle_mounted_response_middleware(self, middleware, request, response, *args, **kwargs):
+    async def _handle_mounted_response_middleware(self, middleware, request,
+                                                  response, *args, **kwargs):
         for mid in middleware:
             _response = mid(request, response, *args, **kwargs)
             if isawaitable(_response):
@@ -676,7 +682,6 @@ class Sanic:
                 response = _response
                 break
         return response
-
 
     def _helper(self, host="127.0.0.1", port=8000, debug=False,
                 ssl=None, sock=None, workers=1, loop=None,

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -3,7 +3,7 @@ import logging.config
 import re
 import warnings
 from asyncio import get_event_loop, ensure_future, CancelledError
-from collections import deque, defaultdict
+from collections import deque, defaultdict, Iterable
 from functools import partial
 from inspect import isawaitable, stack, getmodulename
 from traceback import format_exc
@@ -12,7 +12,7 @@ from ssl import create_default_context, Purpose
 
 from sanic.config import Config, LOGGING
 from sanic.constants import HTTP_METHODS
-from sanic.exceptions import ServerError, URLBuildError, SanicException
+from sanic.exceptions import ServerError, URLBuildError, SanicException, MiddlewareTypeError
 from sanic.handlers import ErrorHandler
 from sanic.log import log
 from sanic.response import HTTPResponse, StreamingHTTPResponse
@@ -110,7 +110,7 @@ class Sanic:
 
     # Decorator
     def route(self, uri, methods=frozenset({'GET'}), host=None,
-              strict_slashes=False):
+              strict_slashes=False, middleware=None):
         """Decorate a function to be registered as a route
 
         :param uri: path of the URL
@@ -125,6 +125,21 @@ class Sanic:
             uri = '/' + uri
 
         def response(handler):
+            # attach middleware to specific handler
+            if middleware:
+                for r in ('request', 'response'):
+                    mid = middleware[r]
+                    if mid:
+                        if callable(mid):
+                            vars(handler)["_"+r+"_middleware"] = mid,
+                        elif isinstance(mid, Iterable):
+                            vars(handler)['_'+r+'_middleware'] = tuple(mid)
+                        else:
+                            raise MiddlewareTypeError(
+                                "Middleware mounted on a handler should " 
+                                "be a function or a sequence of functions"
+                            )
+
             self.router.add(uri=uri, methods=methods, handler=handler,
                             host=host, strict_slashes=strict_slashes)
             return handler
@@ -451,12 +466,9 @@ class Sanic:
 
             request.app = self
             response = await self._run_request_middleware(request)
+
             # No middleware results
             if not response:
-                # -------------------------------------------- #
-                # Execute Handler
-                # -------------------------------------------- #
-
                 # Fetch handler from router
                 handler, args, kwargs, uri = self.router.get(request)
                 request.uri_template = uri
@@ -465,10 +477,30 @@ class Sanic:
                         ("'None' was returned while requesting a "
                          "handler from the router"))
 
-                # Run response handler
-                response = handler(request, *args, **kwargs)
-                if isawaitable(response):
-                    response = await response
+                # request middleware mounted on handler
+                mounted_request_middleware = handler._request_middleware
+                if mounted_request_middleware:
+                    response = await self._handle_mounted_request_middleware(
+                        mounted_request_middleware, request, *args, **kwargs
+                    )
+                # No mounted request middleware result
+                if not response:
+                    # -------------------------------------------- #
+                    # Execute Handler
+                    # -------------------------------------------- #
+                    # Run response handler
+                    response = handler(request, *args, **kwargs)
+                    if isawaitable(response):
+                        response = await response
+
+                # response middleware mounted on handler
+                mounted_response_middleware = handler._response_middleware
+                if mounted_response_middleware:
+                    response = await self._handle_mounted_response_middleware(
+                        mounted_response_middleware, request, response, *args, **kwargs
+                    )
+
+
         except Exception as e:
             # -------------------------------------------- #
             # Response Generation Failed
@@ -623,6 +655,26 @@ class Sanic:
                     response = _response
                     break
         return response
+
+    async def _handle_mounted_request_middleware(self, middleware, request, *args, **kwargs):
+        for mid in middleware:
+            response = mid(request, *args, **kwargs)
+            if isawaitable(response):
+                response = await response
+            if response:
+                break
+        return response
+
+    async def _handle_mounted_response_middleware(self, middleware, request, response, *args, **kwargs):
+        for mid in middleware:
+            _response = mid(request, response, *args, **kwargs)
+            if isawaitable(_response):
+                _response = await _response
+            if _response:
+                response = _response
+                break
+        return response
+
 
     def _helper(self, host="127.0.0.1", port=8000, debug=False,
                 ssl=None, sock=None, workers=1, loop=None,

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -483,10 +483,10 @@ class Sanic:
                     mounted_request_middleware = handler._request_middleware
                     if mounted_request_middleware:
                         response = \
-                        await self._handle_mounted_request_middleware(
-                            mounted_request_middleware, request,
-                            *args, **kwargs
-                        )
+                            await self._handle_mounted_request_middleware(
+                                mounted_request_middleware, request,
+                                *args, **kwargs
+                            )
                 # No mounted request middleware result
                 if not response:
                     # -------------------------------------------- #
@@ -502,10 +502,10 @@ class Sanic:
                     mounted_response_middleware = handler._response_middleware
                     if mounted_response_middleware:
                         response = \
-                        await self._handle_mounted_response_middleware(
-                            mounted_response_middleware, request, response,
-                            *args, **kwargs
-                        )
+                            await self._handle_mounted_response_middleware(
+                                mounted_response_middleware, request, response,
+                                *args, **kwargs
+                            )
 
         except Exception as e:
             # -------------------------------------------- #

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -139,8 +139,6 @@ class Sanic:
                                 "Middleware mounted on a handler should " 
                                 "be a function or a sequence of functions"
                             )
-                    else:
-                        vars(handler)["_"+r+"_middleware"] = ()
 
             self.router.add(uri=uri, methods=methods, handler=handler,
                             host=host, strict_slashes=strict_slashes)
@@ -480,11 +478,12 @@ class Sanic:
                          "handler from the router"))
 
                 # request middleware mounted on handler
-                mounted_request_middleware = handler._request_middleware
-                if mounted_request_middleware:
-                    response = await self._handle_mounted_request_middleware(
-                        mounted_request_middleware, request, *args, **kwargs
-                    )
+                if hasattr(handler, "_request_middleware"):
+                    mounted_request_middleware = handler._request_middleware
+                    if mounted_request_middleware:
+                        response = await self._handle_mounted_request_middleware(
+                            mounted_request_middleware, request, *args, **kwargs
+                        )
                 # No mounted request middleware result
                 if not response:
                     # -------------------------------------------- #
@@ -496,11 +495,12 @@ class Sanic:
                         response = await response
 
                 # response middleware mounted on handler
-                mounted_response_middleware = handler._response_middleware
-                if mounted_response_middleware:
-                    response = await self._handle_mounted_response_middleware(
-                        mounted_response_middleware, request, response, *args, **kwargs
-                    )
+                if hasattr(handler, "_response_middleware"):
+                    mounted_response_middleware = handler._response_middleware
+                    if mounted_response_middleware:
+                        response = await self._handle_mounted_response_middleware(
+                            mounted_response_middleware, request, response, *args, **kwargs
+                        )
 
 
         except Exception as e:

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -175,5 +175,6 @@ class ContentRangeError(SanicException):
 class InvalidRangeType(ContentRangeError):
     pass
 
+
 class MiddlewareTypeError(Exception):
     pass

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -174,3 +174,6 @@ class ContentRangeError(SanicException):
 
 class InvalidRangeType(ContentRangeError):
     pass
+
+class MiddlewareTypeError(Exception):
+    pass

--- a/tests/test_mounted_middleware.py
+++ b/tests/test_mounted_middleware.py
@@ -106,7 +106,7 @@ def test_mounted_response_middleware():
     results = []
 
     async def response_middleware(request, response):
-        response.response_middleware_added = "TEST"
+        results.append(42)
 
     @app.route('/', middleware={"response": response_middleware})
     async def handler(request):
@@ -114,7 +114,7 @@ def test_mounted_response_middleware():
 
     request, response = app.test_client.get('/')
 
-    assert response.response_middleware_added == "TEST"
+    assert results[0] == 42
 
 
 def test_early_response_from_mounted_response_middleware():
@@ -128,7 +128,7 @@ def test_early_response_from_mounted_response_middleware():
 
     async def early_response_middleware(request, response):
         results.append(added[2])
-        return response.text(response.text+"middlewareOK")
+        response.headers.update({"Added": "Response Middleware"})
     
     def not_called_response_middleware(requst, response):
         results.append(added[3])
@@ -149,7 +149,9 @@ def test_early_response_from_mounted_response_middleware():
     for i,v in enumerate(added):
         if i != 3:
             assert results[i] == added[i]
+
     assert len(results) == 3
+    assert response.headers["Added"]== "Response Middleware"
 
 def test_mounted_response_middleware_parameter():
     app = Sanic("test_mounted_response_middleware_parameter")

--- a/tests/test_mounted_middleware.py
+++ b/tests/test_mounted_middleware.py
@@ -181,3 +181,4 @@ def test_exception():
             return text("BAD")
     except MiddlewareTypeError as ex:
         assert str(ex) == "Middleware mounted on a handler should be a function or a sequence of functions"
+

--- a/tests/test_mounted_middleware.py
+++ b/tests/test_mounted_middleware.py
@@ -1,0 +1,183 @@
+from json import loads as json_loads, dumps as json_dumps
+from sanic import Sanic
+from sanic.request import Request
+from sanic.response import json, text, HTTPResponse
+from sanic.exceptions import MiddlewareTypeError
+
+
+# ------------------------------------------------------------ #
+#  GET
+# ------------------------------------------------------------ #
+
+def test_mounted_request_middleware():
+    app = Sanic("test_mounted_request_middleware")
+
+    results = []
+    
+    async def request_middleware(request):
+        results.append(request)
+
+    @app.route('/', middleware={"request": request_middleware})
+    async def handler(request):
+        return text("OK")
+
+    request, response = app.test_client.get('/')
+    
+    assert response.text == "OK"
+    assert type(results[0]) is Request
+
+def test_early_response_from_mounted_request_middleware():
+    app = Sanic("test_early_response_from_mounted_request_middleware")
+
+    results = []
+
+    async def early_request_middleware(request):
+        results.append(1)
+        return text("response from early_request_middleware")
+
+    @app.route('/', middleware={"request": early_request_middleware})
+    async def handler(request):
+        results.append(2)
+        return text("response from handler")
+
+    request, response = app.test_client.get('/')
+
+    assert response.text == "reponse from early_request_middleware"
+    assert results[0] == 1
+    assert len(results) == 1
+
+def test_multi_mounted_request_middleware():
+    app = Sanic("test_multi_mounted_request_middleware")
+
+    results = []
+    added = ['ADD1', 'aADD1', 'ADD2', 'aADD2']
+
+    def mounted_request_middleware1(request):
+        results.append(added[0])
+    
+    async def mounted_async_request_middleware1(request):
+        results.append(added[1])
+
+    def mounted_request_middleware2(request):
+        results.append(added[2])
+    
+    async def mounted_async_request_middleware2(request):
+        results.append(added[3])
+    
+    middlewares = (
+        mounted_request_middleware1,
+        mounted_async_request_middleware1,
+        mounted_request_middleware2,
+        mounted_async_request_middleware2
+    )
+
+    @app.route('/', middleware={"request": middlewares})
+    async def handler(request):
+        return text("OK")
+
+    request, response = app.test_client.get('/')
+
+    for i, v in enumerate(added):
+        assert results[i] == added[i]
+
+    assert response.text == "OK"
+
+def test_mounted_request_middleware_parameter():
+    app = Sanic("test_mounted_request_middleware_parameter")
+
+    results = []
+    async def request_middleware(request, id):
+        results.append(id)
+
+    @app.route('/<id>', middleware={"request": request_middleware})
+    def handler(request, id):
+        return text("OK")
+
+    request, response = app.test_client.get('/42')
+
+    assert results[0] == 42 
+    assert response.text == "OK"
+    
+
+
+def test_mounted_response_middleware():
+    app = Sanic("test_mounted_response_middleware")
+
+    results = []
+
+    async def response_middleware(request, response):
+        response["response_middleware_added"] = "TEST"
+
+    @app.route('/', middleware={"response": response_middleware})
+    async def handler(request):
+        return text("OK")
+
+    request, response = app.test_client.get('/')
+
+    assert response["response_middleware_added"] == "TEST"
+
+
+def test_early_response_from_mounted_response_middleware():
+    app = Sanic("test_early_response_from_mounted_response_middleware")
+
+    results = []
+    added = ['hADD1', 'mADD2', 'eADD3', 'nADD4']
+
+    def response_middleware(request, response):
+        results.append(added[1])
+
+    async def early_response_middleware(request, response):
+        results.append(added[2])
+        return response.text(response.text+"middlewareOK")
+    
+    def not_called_response_middleware(requst, response):
+        results.append(added[3])
+
+    middlewares = [
+        response_middleware,
+        early_response_middleware,
+        not_called_response_middleware
+    ]
+
+    @app.route('/', middleware={"response": middlewares})
+    def handler(request):
+        results.append(added[0])        
+        return text('handlerOK')
+
+    request, response = app.test_client.get('/')
+
+    for i,v in enumerate(added):
+        if i != 3:
+            assert results[i] == added[i]
+        else:
+            assert results[i] != added[i]
+
+def test_mounted_response_middleware_parameter():
+    app = Sanic("test_mounted_response_middleware_parameter")
+
+    results = []
+
+    async def response_middleware(request, response, id):
+        results.append(id)
+
+    @app.route('/<id>', middleware={"response": response_middleware})
+    async def handler(request, id):
+        return text("OK")
+
+    request, response = app.test_client.get('/42')
+
+    assert results[0] == 42
+    assert response.text == "OK"
+    
+
+def test_exception():
+    app = Sanic("test_exception")
+
+    wrong_request = 123
+
+    try:
+        @app.route('/', middleware={"request": wrong_request})
+        async def handler1(request):
+            return text("BAD")
+    except MiddlewareTypeError as ex:
+        assert str(ex) == "Middleware mounted on a handler should be a function or a sequence of functions"

--- a/tests/test_mounted_middleware.py
+++ b/tests/test_mounted_middleware.py
@@ -129,6 +129,7 @@ def test_early_response_from_mounted_response_middleware():
     async def early_response_middleware(request, response):
         results.append(added[2])
         response.headers.update({"Added": "Response Middleware"})
+        return response
     
     def not_called_response_middleware(requst, response):
         results.append(added[3])

--- a/tests/test_mounted_middleware.py
+++ b/tests/test_mounted_middleware.py
@@ -42,7 +42,7 @@ def test_early_response_from_mounted_request_middleware():
 
     request, response = app.test_client.get('/')
 
-    assert response.text == "reponse from early_request_middleware"
+    assert response.text == "response from early_request_middleware"
     assert results[0] == 1
     assert len(results) == 1
 
@@ -95,7 +95,7 @@ def test_mounted_request_middleware_parameter():
 
     request, response = app.test_client.get('/42')
 
-    assert results[0] == 42 
+    assert results[0] == str(42)
     assert response.text == "OK"
     
 
@@ -106,7 +106,7 @@ def test_mounted_response_middleware():
     results = []
 
     async def response_middleware(request, response):
-        response["response_middleware_added"] = "TEST"
+        response.response_middleware_added = "TEST"
 
     @app.route('/', middleware={"response": response_middleware})
     async def handler(request):
@@ -114,7 +114,7 @@ def test_mounted_response_middleware():
 
     request, response = app.test_client.get('/')
 
-    assert response["response_middleware_added"] == "TEST"
+    assert response.response_middleware_added == "TEST"
 
 
 def test_early_response_from_mounted_response_middleware():
@@ -149,8 +149,7 @@ def test_early_response_from_mounted_response_middleware():
     for i,v in enumerate(added):
         if i != 3:
             assert results[i] == added[i]
-        else:
-            assert results[i] != added[i]
+    assert len(results) == 3
 
 def test_mounted_response_middleware_parameter():
     app = Sanic("test_mounted_response_middleware_parameter")
@@ -166,7 +165,7 @@ def test_mounted_response_middleware_parameter():
 
     request, response = app.test_client.get('/42')
 
-    assert results[0] == 42
+    assert results[0] == str(42)
     assert response.text == "OK"
     
 


### PR DESCRIPTION
Hi everyone,
Currently when adding a middleware using `@app.middleware`, we're adding them globally.
It seems more flexible if we could add middleware only to interested handlers. This pull request aims to support this feature. It works like below:
`
async def authenticate(request, lock_id):
    if lock_id != request.headers['key_id']:
        return response.json(
            status=403,
            headers={"Authentication": "Failed"}
        )

async def say_goodby(request, respone, lock_id):
    respone.headers.update({"Add-Header": "May the force be with you"})

@app.route('/lock/<lock_id>', middleware={"request": authenticate, "response": say_goodbye})
async def handler(request, lock_id):
    return response.json({"message": "welcome back"})
`
Adding middleware to interested handlers by passing a middleware keyword argument to route decorator.

We can also pass multi-middleware as a list of functions to middleware keyword argument.

It executes a list of functions in order and do a early responding just like global middleware added by `@app.middleware`

All test are clean, you can take a look at [https://travis-ci.org/pandafeeder/sanic](url)

Thanks a lot.