### PR TITLE
Fix "TypeError: not all arguments converted during string formatting"

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -143,7 +143,7 @@ class Request(dict):
     @property
     def ip(self):
         if not hasattr(self, '_ip'):
-            self._ip = self.transport.get_extra_info('peername')
+            self._ip = self.transport.get_extra_info('peername') or (None, None)
         return self._ip
 
     @property

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -143,7 +143,8 @@ class Request(dict):
     @property
     def ip(self):
         if not hasattr(self, '_ip'):
-            self._ip = self.transport.get_extra_info('peername') or (None, None)
+            self._ip = (self.transport.get_extra_info('peername') or
+                        (None, None))
         return self._ip
 
     @property

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -201,7 +201,7 @@ class HttpProtocol(asyncio.Protocol):
                 netlog.info('', extra={
                     'status': response.status,
                     'byte': len(response.body),
-                    'host': '%s:%d' % self.request.ip,
+                    'host': '%s:%d' % (self.request.ip[0], self.request.ip[1]),
                     'request': '%s %s' % (self.request.method,
                                           self.request.url)
                 })


### PR DESCRIPTION
Resolves #716 

socket.getpeername() returns AF_INET6 address family four-tuple, with
flowid and scopeid.

In server's write_response, an exception is raised when an IPv6 client
connects due to four-tuple elements having two unused elements (flowid
and scopeid).

This makes sure that only the first two (host and port) are used in log
string formatting.