### PR TITLE
Check that the Authorization headers are actually provided.

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -79,7 +79,7 @@ class Request(dict):
         :return: token related to request
         """
         auth_header = self.headers.get('Authorization')
-        if 'Token ' in auth_header:
+        if auth_header is not None and 'Token ' in auth_header:
             return auth_header.partition('Token ')[-1]
         else:
             return auth_header

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -182,6 +182,14 @@ def test_token():
 
     assert request.token == token
 
+    # no Authorization headers
+    headers = {
+        'content-type': 'application/json'
+    }
+
+    request, response = app.test_client.get('/', headers=headers)
+
+    assert request.token is None
 
 
 # ------------------------------------------------------------ #


### PR DESCRIPTION
`request.token()` fails when the `Authorization` header is not provided. If I understood the intent correctly, token should return None in case no token has been provided. This should cover for that.

~TODO: Add a regression unittest.~