### PR TITLE
Testing: store JSON response in local request

### DIFF
--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -1,4 +1,5 @@
 import traceback
+from json import JSONDecodeError
 
 from sanic.log import log
 
@@ -26,9 +27,14 @@ class SanicTestClient:
                     session, method.lower())(url, *args, **kwargs) as response:
                 try:
                     response.text = await response.text()
-                    response.json = await response.json()
                 except UnicodeDecodeError as e:
                     response.text = None
+
+                try:
+                    response.json = await response.json()
+                except (JSONDecodeError, UnicodeDecodeError):
+                    response.json = None
+
                 response.body = await response.read()
                 return response
 

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -26,6 +26,7 @@ class SanicTestClient:
                     session, method.lower())(url, *args, **kwargs) as response:
                 try:
                     response.text = await response.text()
+                    response.json = await response.json()
                 except UnicodeDecodeError as e:
                     response.text = None
                 response.body = await response.read()

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -41,6 +41,7 @@ def test_bp_strict_slash():
 
     request, response = app.test_client.get('/get')
     assert response.text == 'OK'
+    assert response.json == None
 
     request, response = app.test_client.get('/get/')
     assert response.status == 404

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -9,9 +9,11 @@ import pytest
 from random import choice
 
 from sanic import Sanic
-from sanic.response import HTTPResponse, stream, StreamingHTTPResponse, file, file_stream
+from sanic.response import HTTPResponse, stream, StreamingHTTPResponse, file, file_stream, json
 from sanic.testing import HOST, PORT
 from unittest.mock import MagicMock
+
+JSON_DATA = {'ok': True}
 
 
 
@@ -33,6 +35,24 @@ async def sample_streaming_fn(response):
     await asyncio.sleep(.001)
     response.write('bar')
 
+
+@pytest.fixture
+def json_app():
+    app = Sanic('json')
+
+    @app.route("/")
+    async def test(request):
+        return json(JSON_DATA)
+
+    return app
+
+
+def test_json_response(json_app):
+    from sanic.response import json_dumps
+    request, response = json_app.test_client.get('/')
+    assert response.status == 200
+    assert response.text == json_dumps(JSON_DATA)
+    assert response.json == JSON_DATA
 
 @pytest.fixture
 def streaming_app():


### PR DESCRIPTION
Hi, I am testing a JSON API and I noticed that the provided test client conveniently replaces the `.text` property of the response object with an actual text, but does not do the same for the `.json` property. This makes tests harder to read because `response.json()` needs to be awaited in each test.

I'm submitting a test that demonstrate the issue and the least invasive fix that I could think of. Let me know if that's acceptable. 

PS I've not added any error handling yet- I'm waiting to see if you think this fix has legs before putting any more work into it.