### PR TITLE
Gunicorn worker hints app weather it is being terminated

### DIFF
--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -159,6 +159,7 @@ class GunicornWorker(base.Worker):
 
     def handle_quit(self, sig, frame):
         self.alive = False
+        self.app.callable.is_running = False
         self.cfg.worker_int(self)
 
     def handle_abort(self, sig, frame):


### PR DESCRIPTION
For now, `Sanic.is_running` is set when the worker is started but not
unset when it is about to be stopped. Setting the flag for quit signal
will not affect working requests, but the `Sanic.is_running` flag still
can be used to support graceful termination.