### PR TITLE
Handle stream 404

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -351,7 +351,10 @@ class Router:
         :param request: Request object
         :return: bool
         """
-        handler = self.get(request)[0]
+        try:
+            handler = self.get(request)[0]
+        except NotFound:
+            return False
         if (hasattr(handler, 'view_class') and
                 hasattr(handler.view_class, request.method.lower())):
             handler = getattr(handler.view_class, request.method.lower())

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -353,7 +353,7 @@ class Router:
         """
         try:
             handler = self.get(request)[0]
-        except NotFound:
+        except (NotFound, InvalidUsage):
             return False
         if (hasattr(handler, 'view_class') and
                 hasattr(handler.view_class, request.method.lower())):

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -180,7 +180,6 @@ def test_request_stream_handle_exception():
                 response.write(body.decode('utf-8'))
         return stream(streaming)
 
-
     # 404
     request, response = app.test_client.post('/in_valid_post', data=data)
     assert response.status == 404

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -163,6 +163,30 @@ def test_request_stream_app():
     assert response.text == data
 
 
+def test_request_stream_handle_exception():
+    '''for handling exceptions properly'''
+
+    app = Sanic('test_request_stream_exception')
+
+    @app.post('/post/<id>', stream=True)
+    async def post(request, id):
+        assert isinstance(request.stream, asyncio.Queue)
+
+        async def streaming(response):
+            while True:
+                body = await request.stream.get()
+                if body is None:
+                    break
+                response.write(body.decode('utf-8'))
+        return stream(streaming)
+
+
+    # 404
+    request, response = app.test_client.post('/in_valid_post', data=data)
+    assert response.status == 404
+    assert response.text == 'Error: Requested URL /in_valid_post not found'
+
+
 def test_request_stream_blueprint():
     '''for self.is_request_stream = True'''
 

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -185,6 +185,11 @@ def test_request_stream_handle_exception():
     assert response.status == 404
     assert response.text == 'Error: Requested URL /in_valid_post not found'
 
+    # 405
+    request, response = app.test_client.get('/post/random_id', data=data)
+    assert response.status == 405
+    assert response.text == 'Error: Method GET not allowed for URL /post/random_id'
+
 
 def test_request_stream_blueprint():
     '''for self.is_request_stream = True'''


### PR DESCRIPTION
This PR is for fixing https://github.com/channelcat/sanic/issues/759

The root cause is that it calls `self.router.is_stream_handler(self.request)` in on_headers_complete, inside is_stream_handler, it tries to get the handler again (https://github.com/channelcat/sanic/blob/master/sanic/router.py#L354), which will raise another exception during handling the NotFound exception, because it cannot find matched handler and will raise NotFound again, and errors out in https://github.com/channelcat/sanic/blob/master/sanic/router.py#L354.

if the exception is NotFound, we should make is_stream_handler returns False directly, instead of raising another NotFound.