### PR TITLE
Prevent `run` from overriding logging config set in constructor

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -567,6 +567,7 @@ class Sanic:
             host, port = host or "127.0.0.1", port or 8000
 
         if log_config:
+            self.log_config = log_config
             logging.config.dictConfig(log_config)
         if protocol is None:
             protocol = (WebSocketProtocol if self.websocket_enabled
@@ -580,7 +581,7 @@ class Sanic:
             host=host, port=port, debug=debug, ssl=ssl, sock=sock,
             workers=workers, protocol=protocol, backlog=backlog,
             register_sys_signals=register_sys_signals,
-            has_log=log_config is not None)
+            has_log=self.log_config is not None)
 
         try:
             self.is_running = True

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -545,7 +545,7 @@ class Sanic:
     def run(self, host=None, port=None, debug=False, ssl=None,
             sock=None, workers=1, protocol=None,
             backlog=100, stop_event=None, register_sys_signals=True,
-            log_config=LOGGING):
+            log_config=None):
         """Run the HTTP Server and listen until keyboard interrupt or term
         signal. On termination, drain connections before closing.
 


### PR DESCRIPTION
When creating the `Sanic` instance I provide it with a customized `log_config`.
Calling `run` overrides these settings unless I provide it *again* with the same `log_config`.
This is confusing and error prone. `run` shouldnt override configurations set in the `Sanic` constructor...