### PR TITLE
Recycling gunicorn worker

### DIFF
--- a/docs/sanic/deploying.md
+++ b/docs/sanic/deploying.md
@@ -57,6 +57,12 @@ for Gunicorn `worker-class` argument:
 gunicorn myapp:app --bind 0.0.0.0:1337 --worker-class sanic.worker.GunicornWorker
 ```
 
+If your application suffers from memory leaks, you can configure Gunicorn to gracefully restart a worker
+after it has processed a given number of requests. This can be a convenient way to help limit the effects
+of the memory leak.
+
+See the [Gunicorn Docs](http://docs.gunicorn.org/en/latest/settings.html#max-requests) for more information.
+
 ## Asynchronous support
 This is suitable if you *need* to share the sanic process with other applications, in particular the `loop`.
 However be advised that this method does not support using multiple processes, and is not the preferred way

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -432,8 +432,6 @@ def serve(host, port, request_handler, error_handler, before_start=None,
     if debug:
         loop.set_debug(debug)
 
-    trigger_events(before_start, loop)
-
     connections = connections if connections is not None else set()
     server = partial(
         protocol,
@@ -463,12 +461,15 @@ def serve(host, port, request_handler, error_handler, before_start=None,
         sock=sock,
         backlog=backlog
     )
+
     # Instead of pulling time at the end of every request,
     # pull it once per minute
     loop.call_soon(partial(update_current_time, loop))
 
     if run_async:
         return server_coroutine
+
+    trigger_events(before_start, loop)
 
     try:
         http_server = loop.run_until_complete(server_coroutine)

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -74,8 +74,8 @@ class HttpProtocol(asyncio.Protocol):
     def __init__(self, *, loop, request_handler, error_handler,
                  signal=Signal(), connections=set(), request_timeout=60,
                  request_max_size=None, request_class=None, has_log=True,
-                 keep_alive=True, is_request_stream=False, router=None, state=None,
-                 **kwargs):
+                 keep_alive=True, is_request_stream=False, router=None,
+                 state=None, **kwargs):
         self.loop = loop
         self.transport = None
         self.request = None

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -157,6 +157,7 @@ class HttpProtocol(asyncio.Protocol):
             self.headers = []
             self.parser = HttpRequestParser(self)
 
+        # requests count
         self.state['requests_count'] = self.state['requests_count'] + 1
 
         # Parse request chunk or close connection

--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -176,3 +176,4 @@ class GunicornWorker(base.Worker):
         self.alive = False
         self.exit_code = 1
         self.cfg.worker_abort(self)
+        sys.exit(1)

--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -119,7 +119,9 @@ class GunicornWorker(base.Worker):
                 )
                 if self.max_requests and req_count > self.max_requests:
                     self.alive = False
-                    self.log.info("Max requests exceeded, shutting down: %s", self)
+                    self.log.info(
+                            "Max requests exceeded, shutting down: %s", self
+                        )
                 elif pid == os.getpid() and self.ppid != os.getppid():
                     self.alive = False
                     self.log.info("Parent changed, shutting down: %s", self)

--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -117,9 +117,9 @@ class GunicornWorker(base.Worker):
                 req_count = sum(
                     self.servers[srv]["requests_count"] for srv in self.servers
                 )
-                if self.cfg.max_requests and req_count > self.cfg.max_requests:
+                if self.max_requests and req_count > self.max_requests:
                     self.alive = False
-                    self.log.info("Max requests, shutting down: %s", self)
+                    self.log.info("Max requests exceeded, shutting down: %s", self)
                 elif pid == os.getpid() and self.ppid != os.getppid():
                     self.alive = False
                     self.log.info("Parent changed, shutting down: %s", self)

--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -114,7 +114,9 @@ class GunicornWorker(base.Worker):
             while self.alive:
                 self.notify()
 
-                req_count = sum(self.servers[srv]["requests_count"] for srv in self.servers)
+                req_count = sum(
+                    self.servers[srv]["requests_count"] for srv in self.servers
+                )
                 if self.cfg.max_requests and req_count > self.cfg.max_requests:
                     self.alive = False
                     self.log.info("Max requests, shutting down: %s", self)

--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -115,7 +115,6 @@ class GunicornWorker(base.Worker):
                 self.notify()
 
                 req_count = sum(self.servers[srv]["requests_count"] for srv in self.servers)
-
                 if self.cfg.max_requests and req_count > self.cfg.max_requests:
                     self.alive = False
                     self.log.info("Max requests, shutting down: %s", self)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -42,11 +42,6 @@ def worker():
     return GunicornTestWorker()
 
 
-@pytest.fixture
-def loop():
-    return asyncio.get_event_loop()
-
-
 def test_worker_init_process(worker):
     with mock.patch('sanic.worker.asyncio') as mock_asyncio:
         try:
@@ -79,7 +74,8 @@ def test_handle_quit(worker):
     assert worker.exit_code == 0
 
 
-def test_run_max_requests_exceeded(worker, loop):
+def test_run_max_requests_exceeded(worker):
+    loop = asyncio.new_event_loop()
     worker.ppid = 1
     worker.alive = True
     sock = mock.Mock()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -89,7 +89,7 @@ def test_run_max_requests_exceeded(worker):
         "server1": {"requests_count": 14},
         "server2": {"requests_count": 15},
     }
-    worker.cfg.max_requests = 10
+    worker.max_requests = 10
     worker._run = mock.Mock(wraps=asyncio.coroutine(lambda *a, **kw: None))
 
     # exceeding request count
@@ -98,5 +98,5 @@ def test_run_max_requests_exceeded(worker):
 
     assert worker.alive == False
     worker.notify.assert_called_with()
-    worker.log.info.assert_called_with("Max requests, shutting down: %s",
+    worker.log.info.assert_called_with("Max requests exceeded, shutting down: %s",
                                        worker)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -20,3 +20,65 @@ def test_gunicorn_worker(gunicorn_worker):
     with urllib.request.urlopen('http://localhost:1337/') as f:
         res = json.loads(f.read(100).decode())
     assert res['test']
+
+
+#########################################################
+from unittest import mock
+from sanic.worker import GunicornWorker
+from sanic.app import Sanic
+import asyncio
+import logging
+from aiohttp.test_utils import make_mocked_coro
+
+
+class GunicornTestWorker(GunicornWorker):
+
+    def __init__(self):
+        self.app = mock.Mock()
+        self.app.callable = Sanic("test_gunicorn_worker")
+        self.servers = {}
+        self.exit_code = 0
+        self.cfg = mock.Mock()
+
+
+@pytest.fixture
+def worker():
+    return GunicornTestWorker()
+
+
+@pytest.fixture
+def loop():
+    return asyncio.get_event_loop()
+
+
+def test_worker_init_process(worker):
+    with mock.patch('sanic.worker.asyncio') as mock_asyncio:
+        try:
+            worker.init_process()
+        except TypeError:
+            pass
+
+        assert mock_asyncio.get_event_loop.return_value.close.called
+        assert mock_asyncio.new_event_loop.called
+        assert mock_asyncio.set_event_loop.called
+
+
+def test_worker_init_signals(worker):
+    worker.loop = mock.Mock()
+    worker.init_signals()
+    assert worker.loop.add_signal_handler.called
+
+
+def test_handle_abort(worker):
+    with mock.patch('sanic.worker.sys') as mock_sys:
+        worker.handle_abort(object(), object())
+        assert not worker.alive
+        assert worker.exit_code == 1
+        mock_sys.exit.assert_called_with(1)
+
+
+def test_handle_quit(worker):
+    worker.handle_quit(object(), object())
+    assert not worker.alive
+    assert worker.exit_code == 0
+


### PR DESCRIPTION
https://github.com/channelcat/sanic/issues/713

1. add recycling feature, it's important when memory leaks.
2. add unit tests for gunicorn worker
3. trigger_events(before_start, loop) has been called twice when using gunicorn worker. fixed that.