### PR TITLE
Fix testing code for non-json handlers

### DIFF
--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -1,5 +1,6 @@
 import traceback
 from json import JSONDecodeError
+from aiohttp import ClientResponseError
 
 from sanic.log import log
 
@@ -32,7 +33,7 @@ class SanicTestClient:
 
                 try:
                     response.json = await response.json()
-                except (JSONDecodeError, UnicodeDecodeError):
+                except (ClientResponseError, JSONDecodeError, UnicodeDecodeError):
                     response.json = None
 
                 response.body = await response.read()


### PR DESCRIPTION
…json handler

I'm trying to test a simple handler that returns `text('OK')`.
The `await response.json()` statement will throw a `ClientResponseError` since obviously I dont have 'application/json' in my content-type response header (see client_reqrep.py line #717).
That error isn't caught which causes test to fail...