### PR TITLE
Allow textual responses when using test_client and aiohttp 2

### DIFF
--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -32,7 +32,7 @@ class SanicTestClient:
 
                 try:
                     response.json = await response.json()
-                except (JSONDecodeError, UnicodeDecodeError):
+                except (JSONDecodeError, UnicodeDecodeError, aiohttp.ClientResponseError):
                     response.json = None
 
                 response.body = await response.read()

--- a/sanic/testing.py
+++ b/sanic/testing.py
@@ -32,7 +32,9 @@ class SanicTestClient:
 
                 try:
                     response.json = await response.json()
-                except (JSONDecodeError, UnicodeDecodeError, aiohttp.ClientResponseError):
+                except (JSONDecodeError,
+                        UnicodeDecodeError,
+                        aiohttp.ClientResponseError):
                     response.json = None
 
                 response.body = await response.read()


### PR DESCRIPTION
Currently, you're unable to run tests if you're already relying on aiohttp 2, due to the fact that it throws an `aiohttp.ClientResponseError`. That's entirely fine if the response is actually textual, so let's catch it and handle it.

The change is backwards-compatible, since aiohttp 1 has the particular exception, but does not throw it.