### PR TITLE
Added support for 'Authorization: Bearer <TOKEN>' header...

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -86,11 +86,15 @@ class Request(dict):
 
         :return: token related to request
         """
+        prefixes = ('Token ', 'Bearer ')
         auth_header = self.headers.get('Authorization')
-        if auth_header is not None and 'Token ' in auth_header:
-            return auth_header.partition('Token ')[-1]
-        else:
-            return auth_header
+
+        if auth_header is not None:
+            for prefix in prefixes:
+                if prefix in auth_header:
+                    return auth_header.partition(prefix)[-1]
+
+        return auth_header
 
     @property
     def form(self):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -181,6 +181,16 @@ def test_token():
     request, response = app.test_client.get('/', headers=headers)
 
     assert request.token == token
+    
+    token = 'a1d895e0-553a-421a-8e22-5ff8ecb48cbf'
+    headers = {
+        'content-type': 'application/json',
+        'Authorization': 'Bearer {}'.format(token)
+    }
+
+    request, response = app.test_client.get('/', headers=headers)
+
+    assert request.token == token
 
     # no Authorization headers
     headers = {


### PR DESCRIPTION
...in `Request.token` property.

Also added a test case for that kind of header.