### PR TITLE
Inverted the order of prefixes in Request.token property.

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -86,7 +86,7 @@ class Request(dict):
 
         :return: token related to request
         """
-        prefixes = ('Token ', 'Bearer ')
+        prefixes = ('Bearer', 'Token ')
         auth_header = self.headers.get('Authorization')
 
         if auth_header is not None:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -86,13 +86,13 @@ class Request(dict):
 
         :return: token related to request
         """
-        prefixes = ('Bearer', 'Token ')
+        prefixes = ('Bearer', 'Token')
         auth_header = self.headers.get('Authorization')
 
         if auth_header is not None:
             for prefix in prefixes:
                 if prefix in auth_header:
-                    return auth_header.partition(prefix)[-1]
+                    return auth_header.partition(prefix)[-1].strip()
 
         return auth_header
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -175,16 +175,6 @@ def test_token():
     token = 'a1d895e0-553a-421a-8e22-5ff8ecb48cbf'
     headers = {
         'content-type': 'application/json',
-        'Authorization': 'Bearer Token {}'.format(token)
-    }
-
-    request, response = app.test_client.get('/', headers=headers)
-
-    assert request.token == token
-    
-    token = 'a1d895e0-553a-421a-8e22-5ff8ecb48cbf'
-    headers = {
-        'content-type': 'application/json',
         'Authorization': 'Bearer {}'.format(token)
     }
 


### PR DESCRIPTION
As suggested by @allan-simon
See: https://github.com/channelcat/sanic/pull/811#pullrequestreview-46144327