### PR TITLE
Adding version to blueprints

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -14,7 +14,7 @@ FutureStatic = namedtuple('Route',
 
 
 class Blueprint:
-    def __init__(self, name, url_prefix=None, host=None):
+    def __init__(self, name, url_prefix=None, host=None, version='1.0.0'):
         """Create a new blueprint
 
         :param name: unique name of the blueprint
@@ -23,6 +23,7 @@ class Blueprint:
         self.name = name
         self.url_prefix = url_prefix
         self.host = host
+        self.version = version
 
         self.routes = []
         self.websocket_routes = []


### PR DESCRIPTION
I can imagine this could be useful in a lot of cases where people may want to create different versions of their blueprints. This could be expanded on later to do potentially help with routing optionally. For now i just want to include it as an option that i can access through the blueprint object.