### PR TITLE
ensure loop.close() and sys.exit() in gunicorn worker

### DIFF
--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -3,6 +3,7 @@ import sys
 import signal
 import asyncio
 import logging
+import traceback
 
 try:
     import ssl
@@ -69,10 +70,16 @@ class GunicornWorker(base.Worker):
             trigger_events(self._server_settings.get('before_stop', []),
                            self.loop)
             self.loop.run_until_complete(self.close())
+        except:
+            traceback.print_exc()
         finally:
-            trigger_events(self._server_settings.get('after_stop', []),
-                           self.loop)
-            self.loop.close()
+            try:
+                trigger_events(self._server_settings.get('after_stop', []),
+                               self.loop)
+            except:
+                traceback.print_exc()
+            finally:
+                self.loop.close()
 
         sys.exit(self.exit_code)
 


### PR DESCRIPTION
And printing server listeners errors rather than ignoring them