### PR TITLE
don't let default LOGGING to dictConfig influence already existed configs

### DIFF
--- a/sanic/config.py
+++ b/sanic/config.py
@@ -17,6 +17,7 @@ _address_dict = {
 
 LOGGING = {
     'version': 1,
+    'disable_existing_loggers': False,
     'filters': {
         'accessFilter': {
             '()': DefaultFilter,


### PR DESCRIPTION
related to https://github.com/channelcat/sanic/issues/805
and https://github.com/channelcat/sanic/issues/758

in python3 logging, disable_existing_loggers is set to True by default
set it to False in default configuration so that our LOGGING won't disable any other loggers created by our users.