### PR TITLE
revert 599fbce

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -33,9 +33,7 @@ class Sanic:
             logging.config.dictConfig(log_config)
         # Only set up a default log handler if the
         # end-user application didn't set anything up.
-        if not (logging.root.handlers and
-                log.level == logging.NOTSET and
-                log_config):
+        if not logging.root.handlers and log.level == logging.NOTSET:
             formatter = logging.Formatter(
                 "%(asctime)s: %(levelname)s: %(message)s")
             handler = logging.StreamHandler()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,7 @@
-import asyncio
 import uuid
+from importlib import reload
+
+from sanic.config import LOGGING
 from sanic.response import text
 from sanic import Sanic
 from io import StringIO
@@ -8,6 +10,11 @@ import logging
 logging_format = '''module: %(module)s; \
 function: %(funcName)s(); \
 message: %(message)s'''
+
+
+def reset_logging():
+    logging.shutdown()
+    reload(logging)
 
 
 def test_log():
@@ -31,6 +38,20 @@ def test_log():
     request, response = app.test_client.get('/')
     log_text = log_stream.getvalue()
     assert rand_string in log_text
+
+
+def test_default_log_fmt():
+
+    reset_logging()
+    Sanic()
+    for fmt in [h.formatter for h in logging.getLogger('sanic').handlers]:
+        assert fmt._fmt == LOGGING['formatters']['simple']['format']
+
+    reset_logging()
+    Sanic(log_config=None)
+    for fmt in [h.formatter for h in logging.getLogger('sanic').handlers]:
+        assert fmt._fmt == "%(asctime)s: %(levelname)s: %(message)s"
+
 
 if __name__ == "__main__":
     test_log()


### PR DESCRIPTION
This reverts commit 599fbcee6e1e427829a9f03de7f7aad2ee67ac22.

Hi, @r0fls , I think #790 doesn't fix #752, actually it's #795 that fixed the issue. Besides, #790 introduces an another issue, a default log handler will be added to the sanic logger even when the end-user has set one. Maybe the condition should be:
```python
        if not (logging.root.handlers and
                log.level != logging.NOTSET and
                log_config):
```

Please correct me if I miss something :)