### PR TITLE
Fix issue with parsing multipart body from unirest

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -265,7 +265,7 @@ def parse_multipart_form(body, boundary):
                 if 'filename' in form_parameters:
                     file_name = form_parameters['filename']
                 field_name = form_parameters.get('name')
-            elif form_header_field == 'content-type':
+            elif form_header_field == 'content-type' and file_name:
                 file_type = form_header_value
 
         post_data = form_part[line_index:-4]


### PR DESCRIPTION
Some libraries e.g. unirest always put Content-Type inside every chunk.
Even though, it is a simple text/plain. This makes Sanic, mistakenly,
treats that chunk as file.

This commit made sure only chunks with "filename" after
Content-Disposition are treated as files.