### PR TITLE
Fix cov report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     gunicorn
 commands =
     pytest tests --cov sanic --cov-report= {posargs}
-    coverage combine --append
+    - coverage combine --append
     coverage report -m
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,9 @@ deps =
     beautifulsoup4
     gunicorn
 commands =
-    pytest tests --cov sanic --cov-report term-missing {posargs}
+    pytest tests --cov sanic --cov-report= {posargs}
+    coverage combine --append
+    coverage report -m
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
This PR has a workaround fix for `incorrect coverage report`, the root cause is that `pytest` load  plugins randomly.

You can check last travis ci build of master branch to see the `incorrect coverage report`.
More context here: https://github.com/pytest-dev/pytest-cov/issues/117