### PR TITLE
feat(examples): add `add_task_sanic.py`

### DIFF
--- a/examples/add_task_sanic.py
+++ b/examples/add_task_sanic.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+
+from sanic import Sanic
+
+app = Sanic()
+
+
+async def notify_server_started_after_five_seconds():
+    await asyncio.sleep(5)
+    print('Server successfully started!')
+
+app.add_task(notify_server_started_after_five_seconds())
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)


### PR DESCRIPTION
In the examples, I do not find a demo with `add_task`. In my opinion, `add_task` is a very interesting
feature in `sanic`.

Hope the demo can be added in `examples`, and `sanic` become more powerful and more popular

Thanks. 