### PR TITLE
recovery ujson error 

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -4,7 +4,7 @@ from os import path
 try:
     from ujson import dumps as json_dumps
 except:
-    from json import dumps as jjson_dumps
+    from json import dumps as json_dumps
 finally:
     from json import dumps as jjson_dumps
 from aiofiles import open as open_async

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -2,10 +2,11 @@ from mimetypes import guess_type
 from os import path
 
 try:
-    from ujson import dumps as json_dumps
+    from ujson import dumps as ujson_dumps
 except:
-    from json import dumps as json_dumps
-
+    from json import dumps as jjson_dumps
+finally:
+    from json import dumps as jjson_dumps
 from aiofiles import open as open_async
 
 from sanic.cookies import CookieJar
@@ -244,8 +245,12 @@ def json(body, status=200, headers=None,
     :param headers: Custom Headers.
     :param kwargs: Remaining arguments that are passed to the json encoder.
     """
-    return HTTPResponse(json_dumps(body, **kwargs), headers=headers,
-                        status=status, content_type=content_type)
+    try:
+        return HTTPResponse(ujson_dumps(body, **kwargs), headers=headers,
+                            status=status, content_type=content_type)
+    except Exception as e:
+        return HTTPResponse(jjson_dumps(body, **kwargs), headers=headers,
+                            status=status, content_type=content_type)
 
 
 def text(body, status=200, headers=None,

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -2,7 +2,7 @@ from mimetypes import guess_type
 from os import path
 
 try:
-    from ujson import dumps as ujson_dumps
+    from ujson import dumps as json_dumps
 except:
     from json import dumps as jjson_dumps
 finally:
@@ -246,7 +246,7 @@ def json(body, status=200, headers=None,
     :param kwargs: Remaining arguments that are passed to the json encoder.
     """
     try:
-        return HTTPResponse(ujson_dumps(body, **kwargs), headers=headers,
+        return HTTPResponse(json_dumps(body, **kwargs), headers=headers,
                             status=status, content_type=content_type)
     except Exception as e:
         return HTTPResponse(jjson_dumps(body, **kwargs), headers=headers,


### PR DESCRIPTION
Sanic use ultra-json as its default json parser, but sometimes when ujson dumps some special dict ,it will raise some Exception such as **OverflowError: Invalid Nan value when encoding double** , but the standard json library would not . So I suggest to add a mechanism in Sanic that when the `ujson.dumps` raise Exception , we should use the standard json library and  try it again