### PR TITLE
make the prefix for environment variables alterable

### DIFF
--- a/docs/sanic/config.md
+++ b/docs/sanic/config.md
@@ -29,9 +29,15 @@ In general the convention is to only have UPPERCASE configuration parameters. Th
 
 There are several ways how to load configuration.
 
-### From environment variables.
+### From Environment Variables
 
-Any variables defined with the `SANIC_` prefix will be applied to the sanic config. For example, setting `SANIC_REQUEST_TIMEOUT` will be loaded by the application automatically. You can pass the `load_env` boolean to the Sanic constructor to override that:
+Any variables defined with the `SANIC_` prefix will be applied to the sanic config. For example, setting `SANIC_REQUEST_TIMEOUT` will be loaded by the application automatically and fed into the `REQUEST_TIMEOUT` config variable. You can pass a different prefix to Sanic:
+
+```python
+app = Sanic(load_env='MYAPP_')
+```
+
+Then the above variable would be `MYAPP_REQUEST_TIMEOUT`. If you want to disable loading from environment variables you can set it to `False` instead:
 
 ```python
 app = Sanic(load_env=False)

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -131,7 +131,8 @@ class Config(dict):
         self.GRACEFUL_SHUTDOWN_TIMEOUT = 15.0  # 15 sec
 
         if load_env:
-            self.load_environment_vars()
+            prefix = SANIC_PREFIX if load_env == True else load_env
+            self.load_environment_vars(prefix=load_env)
 
     def __getattr__(self, attr):
         try:

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -132,7 +132,7 @@ class Config(dict):
 
         if load_env:
             prefix = SANIC_PREFIX if load_env == True else load_env
-            self.load_environment_vars(prefix=load_env)
+            self.load_environment_vars(prefix=prefix)
 
     def __getattr__(self, attr):
         try:

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -195,14 +195,14 @@ class Config(dict):
             if key.isupper():
                 self[key] = getattr(obj, key)
 
-    def load_environment_vars(self):
+    def load_environment_vars(self, prefix=SANIC_PREFIX):
         """
-        Looks for any ``SANIC_`` prefixed environment variables and applies
+        Looks for prefixed environment variables and applies
         them to the configuration if present.
         """
         for k, v in os.environ.items():
-            if k.startswith(SANIC_PREFIX):
-                _, config_key = k.split(SANIC_PREFIX, 1)
+            if k.startswith(prefix):
+                _, config_key = k.split(prefix, 1)
                 try:
                     self[config_key] = int(v)
                 except ValueError:

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -131,7 +131,7 @@ class Config(dict):
         self.GRACEFUL_SHUTDOWN_TIMEOUT = 15.0  # 15 sec
 
         if load_env:
-            prefix = SANIC_PREFIX if load_env == True else load_env
+            prefix = SANIC_PREFIX if load_env is True else load_env
             self.load_environment_vars(prefix=prefix)
 
     def __getattr__(self, attr):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,14 +19,20 @@ def test_load_from_object():
 def test_auto_load_env():
     environ["SANIC_TEST_ANSWER"] = "42"
     app = Sanic()
-    assert app.config.TEST_ANSWER == "42"
+    assert app.config.TEST_ANSWER == 42
     del environ["SANIC_TEST_ANSWER"]
 
-def test_auto_load_env():
+def test_dont_load_env():
     environ["SANIC_TEST_ANSWER"] = "42"
     app = Sanic(load_env=False)
     assert getattr(app.config, 'TEST_ANSWER', None) == None
     del environ["SANIC_TEST_ANSWER"]
+
+def test_load_env_prefix():
+    environ["MYAPP_TEST_ANSWER"] = "42"
+    app = Sanic(load_env='MYAPP_')
+    assert app.config.TEST_ANSWER == 42
+    del environ["MYAPP_TEST_ANSWER"]
 
 def test_load_from_file():
     app = Sanic('test_load_from_file')


### PR DESCRIPTION
Suppose my app is named "Abc", it is really not obvious, why the configuration prefix for environment variables is "SANIC_". Also, if I happen to have more than one Sanic app in one environment, there would be no way to distinguish those. Hence, I propose to make it possible to use other prefixes.