### PR TITLE
fix #763, sanic can't decode latin1 encoded header value

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -189,10 +189,12 @@ class HttpProtocol(asyncio.Protocol):
                     and int(value) > self.request_max_size:
                 exception = PayloadTooLarge('Payload Too Large')
                 self.write_error(exception)
-
+            try:
+                value = value.decode()
+            except UnicodeDecodeError:
+                value = value.decode('latin_1')
             self.headers.append(
-                    (self._header_fragment.decode().casefold(),
-                     value.decode()))
+                    (self._header_fragment.decode().casefold(), value))
 
             self._header_fragment = b''
 


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7230#section-3.2.4,
HTTP headers should be ASCII or latin1 encoded.
So latin1 encoded headers should be handled correctly.
However, some implementations (https://github.com/aio-libs/aiohttp/pull/137)
use UTF-8 encoded header value. So I think UTF-8 should also be handled.

This pull request adds latin1 encoding as fallback when decoding headers.