### PR TITLE
Use dependency injection to allow alternative json parser or encoder

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -71,12 +71,7 @@ class Request(dict):
     @property
     def json(self):
         if self.parsed_json is None:
-            try:
-                self.parsed_json = json_loads(self.body)
-            except Exception:
-                if not self.body:
-                    return None
-                raise InvalidUsage("Failed when parsing body as json")
+            self.load_json()
 
         return self.parsed_json
 

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -69,14 +69,24 @@ class Request(dict):
         self.stream = None
 
     @property
-    def json(self, loads=json_loads):
+    def json(self):
         if self.parsed_json is None:
             try:
-                self.parsed_json = loads(self.body)
+                self.parsed_json = json_loads(self.body)
             except Exception:
                 if not self.body:
                     return None
                 raise InvalidUsage("Failed when parsing body as json")
+
+        return self.parsed_json
+
+    def load_json(self, loads=json_loads):
+        try:
+            self.parsed_json = loads(self.body)
+        except Exception:
+            if not self.body:
+                return None
+            raise InvalidUsage("Failed when parsing body as json")
 
         return self.parsed_json
 

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -69,10 +69,10 @@ class Request(dict):
         self.stream = None
 
     @property
-    def json(self):
+    def json(self, loads=json_loads):
         if self.parsed_json is None:
             try:
-                self.parsed_json = json_loads(self.body)
+                self.parsed_json = loads(self.body)
             except Exception:
                 if not self.body:
                     return None

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -237,7 +237,8 @@ class HTTPResponse(BaseHTTPResponse):
 
 
 def json(body, status=200, headers=None,
-         content_type="application/json", **kwargs):
+         content_type="application/json", dumps=json_dumps,
+         **kwargs):
     """
     Returns response object with body in json format.
 
@@ -246,7 +247,7 @@ def json(body, status=200, headers=None,
     :param headers: Custom Headers.
     :param kwargs: Remaining arguments that are passed to the json encoder.
     """
-    return HTTPResponse(json_dumps(body, **kwargs), headers=headers,
+    return HTTPResponse(dumps(body, **kwargs), headers=headers,
                         status=status, content_type=content_type)
 
 


### PR DESCRIPTION
Allow a custom/alternative JSON encode/decode function to be specified when sending a response or parsing a request. The `response.json` function gets an extra optional keyword argument `dumps`, with obvious default. When parsing a request, instead of the property `request.json` a method `request.load_json(loads=<new loads>)` can be used.

My use case is returning results from calculations, stored as numpy arrays or pandas dataframes. The pandas library has a nice JSON encode/decode module (derived from ujson) which will sensibly (and quickly) handle numpy arrays.

```{python}
import numpy as np
import pandas as pd
import sanic

def a_response_handler(request)
    request_data = request.load_json(loads=pd.json.loads)

# processing would go here

    response_data = {
        "first": np.array([0.0, 1.0, 4.0]),
        "second": np.random.uniform(0, 1, 10)
    }
    return sanic.response.json(response_data, dumps=pd.json.dumps)
```