### PR TITLE
Fix logs

### DIFF
--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -86,12 +86,13 @@ class ErrorHandler:
             self.log(format_exc())
             if self.debug:
                 url = getattr(request, 'url', 'unknown')
-                response_message = (
-                    'Exception raised in exception handler "{}" '
-                    'for uri: "{}"\n{}').format(
-                        handler.__name__, url, format_exc())
-                logger.error(response_message)
-                return text(response_message, 500)
+                response_message = ('Exception raised in exception handler '
+                                    '"%s" for uri: "%s"\n%s')
+                logger.error(response_message,
+                             handler.__name__, url, format_exc())
+
+                return text(response_message % (
+                    handler.__name__, url, format_exc()), 500)
             else:
                 return text('An error occurred while handling an error', 500)
         return response
@@ -114,10 +115,9 @@ class ErrorHandler:
         elif self.debug:
             html_output = self._render_traceback_html(exception, request)
 
-            response_message = (
-                'Exception occurred while handling uri: "{}"\n{}'.format(
-                    request.url, format_exc()))
-            logger.error(response_message)
+            response_message = ('Exception occurred while handling uri: '
+                                '"%s"\n%s')
+            logger.error(response_message, request.url, format_exc())
             return html(html_output, status=500)
         else:
             return html(INTERNAL_SERVER_ERROR_HTML, status=500)

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -337,15 +337,13 @@ class HttpProtocol(asyncio.Protocol):
                     self.keep_alive_timeout))
             self.log_response(response)
         except AttributeError:
-            logger.error(
-                ('Invalid response object for url {}, '
-                 'Expected Type: HTTPResponse, Actual Type: {}').format(
-                    self.url, type(response)))
+            logger.error('Invalid response object for url %s, '
+                         'Expected Type: HTTPResponse, Actual Type: %s',
+                         self.url, type(response))
             self.write_error(ServerError('Invalid response type'))
         except RuntimeError:
-            logger.error(
-                'Connection lost before response written @ {}'.format(
-                    self.request.ip))
+            logger.error('Connection lost before response written @ %s',
+                         self.request.ip)
         except Exception as e:
             self.bail_out(
                 "Writing response failed, connection closed {}".format(
@@ -376,15 +374,13 @@ class HttpProtocol(asyncio.Protocol):
                 self.request.version, keep_alive, self.keep_alive_timeout)
             self.log_response(response)
         except AttributeError:
-            logger.error(
-                ('Invalid response object for url {}, '
-                 'Expected Type: HTTPResponse, Actual Type: {}').format(
-                    self.url, type(response)))
+            logger.error('Invalid response object for url %s, '
+                         'Expected Type: HTTPResponse, Actual Type: %s',
+                         self.url, type(response))
             self.write_error(ServerError('Invalid response type'))
         except RuntimeError:
-            logger.error(
-                'Connection lost before response written @ {}'.format(
-                    self.request.ip))
+            logger.error('Connection lost before response written @ %s',
+                         self.request.ip)
         except Exception as e:
             self.bail_out(
                 "Writing response failed, connection closed {}".format(
@@ -411,9 +407,8 @@ class HttpProtocol(asyncio.Protocol):
             version = self.request.version if self.request else '1.1'
             self.transport.write(response.output(version))
         except RuntimeError:
-            logger.error(
-                'Connection lost before error written @ {}'.format(
-                    self.request.ip if self.request else 'Unknown'))
+            logger.error('Connection lost before error written @ %s',
+                         self.request.ip if self.request else 'Unknown')
         except Exception as e:
             self.bail_out(
                 "Writing error failed, connection closed {}".format(
@@ -427,12 +422,10 @@ class HttpProtocol(asyncio.Protocol):
 
     def bail_out(self, message, from_error=False):
         if from_error or self.transport.is_closing():
-            logger.error(
-                ("Transport closed @ {} and exception "
-                 "experienced during error handling").format(
-                    self.transport.get_extra_info('peername')))
-            logger.debug(
-                'Exception:\n{}'.format(traceback.format_exc()))
+            logger.error("Transport closed @ %s and exception "
+                         "experienced during error handling",
+                         self.transport.get_extra_info('peername'))
+            logger.debug('Exception:\n%s', traceback.format_exc())
         else:
             exception = ServerError(message)
             self.write_error(exception)
@@ -597,15 +590,14 @@ def serve(host, port, request_handler, error_handler, before_start=None,
             try:
                 loop.add_signal_handler(_signal, loop.stop)
             except NotImplementedError:
-                logger.warn(
-                    'Sanic tried to use loop.add_signal_handler but it is'
-                    ' not implemented on this platform.')
+                logger.warning('Sanic tried to use loop.add_signal_handler '
+                               'but it is not implemented on this platform.')
     pid = os.getpid()
     try:
-        logger.info('Starting worker [{}]'.format(pid))
+        logger.info('Starting worker [%s]', pid)
         loop.run_forever()
     finally:
-        logger.info("Stopping worker [{}]".format(pid))
+        logger.info("Stopping worker [%s]", pid)
 
         # Run the on_stop function if provided
         trigger_events(before_stop, loop)
@@ -667,8 +659,7 @@ def serve_multiple(server_settings, workers):
         server_settings['port'] = None
 
     def sig_handler(signal, frame):
-        logger.info("Received signal {}. Shutting down.".format(
-            Signals(signal).name))
+        logger.info("Received signal %s. Shutting down.", Signals(signal).name)
         for process in processes:
             os.kill(process.pid, SIGINT)
 

--- a/sanic/worker.py
+++ b/sanic/worker.py
@@ -142,9 +142,8 @@ class GunicornWorker(base.Worker):
                 )
                 if self.max_requests and req_count > self.max_requests:
                     self.alive = False
-                    self.log.info(
-                            "Max requests exceeded, shutting down: %s", self
-                        )
+                    self.log.info("Max requests exceeded, shutting down: %s",
+                                  self)
                 elif pid == os.getpid() and self.ppid != os.getppid():
                     self.alive = False
                     self.log.info("Parent changed, shutting down: %s", self)


### PR DESCRIPTION
Preferable logging is through percentage sign https://docs.python.org/3/library/logging.html#formatter-objects
It is real issue for integration with Sentry. If message will be trasfered just as formatted string, Sentry will not be able to 'intelligently group messages' (last paragraph).
https://docs.sentry.io/clients/python/integrations/logging/#usage