### PR TITLE
to fix condition error that used in `log_response`

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -311,7 +311,7 @@ class HttpProtocol(asyncio.Protocol):
             else:
                 extra['byte'] = -1
 
-            if self.request:
+            if self.request is not None:
                 extra['host'] = '{0}:{1}'.format(self.request.ip[0],
                                                  self.request.ip[1])
                 extra['request'] = '{0} {1}'.format(self.request.method,


### PR DESCRIPTION
`request` class is derived from **`dict`**, so it will never be **`True`**.