### PR TITLE
Call connection_open after websocket handshake

### DIFF
--- a/sanic/websocket.py
+++ b/sanic/websocket.py
@@ -90,4 +90,5 @@ class WebSocketProtocol(HttpProtocol):
         )
         self.websocket.subprotocol = subprotocol
         self.websocket.connection_made(request.transport)
+        self.websocket.connection_open()
         return self.websocket


### PR DESCRIPTION
It seems that due to (recent?) changes in the websocket library, we
now need to call "connection_open" to flag that the websocket is now
ready to use. I've added that call just after the call to
"connection_made".

Without this call, I've been getting the following error:

```
WebSocket connection isn't established yet
```

From the `protocols.py` file in the websockets library:

```python
        # Control may only reach this point in buggy third-party subclasses.
        assert self.state is State.CONNECTING
        raise InvalidState("WebSocket connection isn't established yet")
```