### PR TITLE
Change unit tests names with repeated names.

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -58,11 +58,11 @@ def exception_app():
         raise InvalidUsage("OK")
 
     @app.route('/abort/401')
-    def handler_invalid(request):
+    def handler_401_error(request):
         abort(401)
 
     @app.route('/abort')
-    def handler_invalid(request):
+    def handler_500_error(request):
         abort(500)
         return text("OK")
 
@@ -186,7 +186,7 @@ def test_exception_in_exception_handler_debug_off(exception_app):
     assert response.body == b'An error occurred while handling an error'
 
 
-def test_exception_in_exception_handler_debug_off(exception_app):
+def test_exception_in_exception_handler_debug_on(exception_app):
     """Test that an exception thrown in an error handler is handled"""
     request, response = exception_app.test_client.get(
         '/error_in_error_handler_handler',

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -164,7 +164,7 @@ def test_static_content_range_error(file_name, static_file_directory):
 
 
 @pytest.mark.parametrize('file_name', ['test.file', 'decode me.txt', 'python.png'])
-def test_static_file(static_file_directory, file_name):
+def test_static_file_specified_host(static_file_directory, file_name):
     app = Sanic('test_static')
     app.static(
         '/testing.file',


### PR DESCRIPTION
Some unit tests had same names in same modules that caused confusing in test failure.