### PR TITLE
Added regex escaping for `Router.add()` version parameter

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -119,10 +119,8 @@ class Router:
         :return: Nothing
         """
         if version is not None:
-            if uri.startswith('/'):
-                uri = "/".join(["/v{}".format(str(version)), uri[1:]])
-            else:
-                uri = "/".join(["/v{}".format(str(version)), uri])
+            version = re.escape(str(version))
+            uri = "/".join(["/v{}".format(version.strip('/')), uri.lstrip('/')])
         # add regular version
         self._add(uri, methods, handler, host, name)
 


### PR DESCRIPTION
Resolve URL for unusual versioning parameters, e.g. version='0.1.dev3+gfb42230.d20171118'