### PR TITLE
Fix ip and socket data format on V6 

### DIFF
--- a/docs/sanic/testing.md
+++ b/docs/sanic/testing.md
@@ -20,7 +20,7 @@ def test_index_put_not_allowed():
     assert response.status == 405
 ```
 
-Internally, each time you call one of the `test_client` methods, the Sanic app is run at `127.0.01:42101` and 
+Internally, each time you call one of the `test_client` methods, the Sanic app is run at `127.0.0.1:42101` and 
 your test request is executed against your application, using `aiohttp`. 
 
 The `test_client` methods accept the following arguments and keyword arguments:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -1,5 +1,6 @@
 import sys
 import json
+import socket
 from cgi import parse_header
 from collections import namedtuple
 from http.cookies import SimpleCookie
@@ -185,9 +186,18 @@ class Request(dict):
         return self._socket
 
     def _get_address(self):
-        self._socket = (self.transport.get_extra_info('peername') or
-                        (None, None))
-        self._ip, self._port = self._socket
+        sock = self.transport.get_extra_info('socket')
+
+        if sock.family == socket.AF_INET:
+            self._socket = (self.transport.get_extra_info('peername') or
+                            (None, None))
+            self._ip, self._port = self._socket
+        elif sock.family == socket.AF_INET6:
+            self._socket = (self.transport.get_extra_info('peername') or
+                            (None, None, None, None))
+            self._ip, self._port, *_ = self._socket
+        else:
+            self._ip, self._port = (None, None)
 
     @property
     def remote_addr(self):


### PR DESCRIPTION
Currently Sanic throws errors when serving IPv6 requests. This fixes the error.