### PR TITLE
Add sphinxcontrib-asyncio to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,5 @@ dependencies:
   - ujson>=1.35
   - aiofiles>=0.3.0
   - websockets>=3.2
+  - sphinxcontrib-asyncio>=0.2.0
   - https://github.com/channelcat/docutils-fork/zipball/master


### PR DESCRIPTION
readthedocs builds were broken because they were missing this dependency,

Won't fix the docs for `0.7.0` (that ship has already sailed) but will fix for future builds.

Also re-added the webhook so hopefully readthedocs builds will now be automated 🤞 