### PR TITLE
remove uvloop for windows setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ if strtobool(os.environ.get("SANIC_NO_UJSON", "no")):
     print("Installing without uJSON")
     requirements.remove(ujson)
 
-if strtobool(os.environ.get("SANIC_NO_UVLOOP", "no")):
+# 'nt' means windows OS
+if strtobool(os.environ.get("SANIC_NO_UVLOOP", "no")) or os.name == 'nt':
     print("Installing without uvLoop")
     requirements.remove(uvloop)
 


### PR DESCRIPTION
Hello

This PR matters for windows users only. I understand that windows user might provide `SANIC_NO_UVLOOP=True` var, but I guess it would be convenient to remove `uvloop` from `setup.py` for windows by default. Just to make it a little easy for tinkering/studying.

Currently, `pip install sanic` leads to an error on windows since uvloop hasn't implemented yet for this platform. 