### PR TITLE
Add support for blueprint groups and nesting

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -372,10 +372,14 @@ class Sanic:
     def blueprint(self, blueprint, **options):
         """Register a blueprint on the application.
 
-        :param blueprint: Blueprint object
+        :param blueprint: Blueprint object or (list, tuple) thereof
         :param options: option dictionary with blueprint defaults
         :return: Nothing
         """
+        if isinstance(blueprint, (list, tuple)):
+            for item in blueprint:
+                self.blueprint(item, **options)
+            return
         if blueprint.name in self.blueprints:
             assert self.blueprints[blueprint.name] is blueprint, \
                 'A blueprint with the name "%s" is already registered.  ' \

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -14,7 +14,6 @@ FutureStatic = namedtuple('Route',
 
 
 class Blueprint:
-
     def __init__(self, name,
                  url_prefix=None,
                  host=None, version=None,
@@ -37,6 +36,27 @@ class Blueprint:
         self.statics = []
         self.version = version
         self.strict_slashes = strict_slashes
+
+    @staticmethod
+    def group(*blueprints, url_prefix=''):
+        """Create a list of blueprints, optionally
+        grouping them under a general URL prefix.
+
+        :param blueprints: blueprints to be registered as a group
+        :param url_prefix: URL route to be prepended to all sub-prefixes
+        """
+        def chain(nested):
+            """itertools.chain() but leaves strings untouched"""
+            for i in nested:
+                if isinstance(i, (list, tuple)):
+                    yield from chain(i)
+                else:
+                    yield i
+        bps = []
+        for bp in chain(blueprints):
+            bp.url_prefix = url_prefix + bp.url_prefix
+            bps.append(bp)
+        return bps
 
     def register(self, app, options):
         """Register the blueprint to the sanic app."""


### PR DESCRIPTION
Hi! I don't know if this is necessarily a productive / up-to-par contribution, but I thought it'd be neat to have support for a backend directory structure that mimics the front-end UX, thereby reducing the amount of `app.blueprint()`s required in the main file to only one. Here's the bit I added to the documentation to explain:

## Blueprint groups and nesting

Blueprints may also be registered as part of a list or tuple, where the registrar will recursively cycle through any sub-sequences of blueprints and register them accordingly. The `Blueprint.group` method is provided to simplify this process, allowing a 'mock' backend directory structure mimicking what's seen from the front end. Consider this (quite contrived) example:

```
api/
├──content/
│  ├──authors.py
│  ├──static.py
│  └──__init__.py
├──info.py
└──__init__.py
app.py
```

Initialization of this app's blueprint hierarchy could go as follows:


```python
# api/content/authors.py
from sanic import Blueprint

authors = Blueprint('content_authors', url_prefix='/authors')
```
```python
# api/content/static.py
from sanic import Blueprint

static = Blueprint('content_static', url_prefix='/static')
```
```python
# api/content/__init__.py
from sanic import Blueprint

from .static import static
from .authors import authors

content = Blueprint.group(assets, authors, url_prefix='/content')
```
```python
# api/info.py
from sanic import Blueprint

info = Blueprint('info', url_prefix='/info')
```
```python
# api/__init__.py
from sanic import Blueprint

from .content import content
from .info import info

api = Blueprint.group(content, info, url_prefix='/api')
```
And registering these blueprints in `app.py` can now be done like so:
```python
# app.py
from sanic import Sanic

from .api import api

app = Sanic(__name__)

app.blueprint(api)
```
  