### PR TITLE
Fix log_response to correctly output request ip and port

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -319,7 +319,8 @@ class HttpProtocol(asyncio.Protocol):
             extra['host'] = 'UNKNOWN'
             if self.request is not None:
                 if self.request.ip:
-                    extra['host'] = '{0[0]}:{0[1]}'.format(self.request.ip)
+                    extra['host'] = '{0}:{1}'.format(self.request.ip,
+                                                     self.request.port)
 
                 extra['request'] = '{0} {1}'.format(self.request.method,
                                                     self.request.url)


### PR DESCRIPTION
Hi Sanic devs,

I noticed that the `sanic.server.HttpProtocol.log_response` in the latest master (9f55981) is incorrectly showing the IP address of the request.

This is because the log simply returns the 0th and 1st item of `self.request.ip`, which is just a string of the request IP. In c2191153, `self.request.ip` was changed from returning `({ip_address_str}, {port_int})` to just `{ip_address_str}`. This PR simply changes the arguments for `.format()` so that `log_response` shows the correct IP and port again.

Please let me know if I should make more changes or add more tests.

Thanks in advance for checking.