### PR TITLE
Fix typo

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -182,7 +182,7 @@ class Request(dict):
     @property
     def socket(self):
         if not hasattr(self, '_socket'):
-            self._get_socket()
+            self._get_address()
         return self._socket
 
     def _get_address(self):


### PR DESCRIPTION
There is no `_get_socket` method, that sets `_socket` attribute, but there is `_get_address` method, that does the tsing (and sets `_ip` and `_port` as well)