### PR TITLE
Add request.method to documentation

### DIFF
--- a/docs/sanic/request_data.md
+++ b/docs/sanic/request_data.md
@@ -73,6 +73,8 @@ The following variables are accessible as properties on `Request` objects:
 
 - `headers` (dict) - A case-insensitive dictionary that contains the request headers.
 
+- `method` (str) - HTTP method of the request (ie `GET`, `POST`).
+
 - `ip` (str) - IP address of the requester.
 
 - `port` (str) - Port address of the requester.


### PR DESCRIPTION
Perhaps `request.method` was missing because it's obvious, but listing it here would have saved me a few minutes.