### PR TITLE
fix log twice

### DIFF
--- a/sanic/log.py
+++ b/sanic/log.py
@@ -14,14 +14,14 @@ LOGGING_CONFIG_DEFAULTS = dict(
         "sanic.error": {
             "level": "INFO",
             "handlers": ["error_console"],
-            "propagate": True,
+            "propagate": False,
             "qualname": "sanic.error"
         },
 
         "sanic.access": {
             "level": "INFO",
             "handlers": ["access_console"],
-            "propagate": True,
+            "propagate": False,
             "qualname": "sanic.access"
         }
     },


### PR DESCRIPTION
When enable "sanic" logger, the "sanic.access" will log twice. Example:

```python
import logging
import logging.config

from sanic import Sanic
from sanic.response import text


log_config = dict(
    version=1,
    disable_existing_loggers=False,
    handlers={
        "console": {
            "formatter": "simple",
            "class": "logging.StreamHandler",
            "stream": "ext://sys.stdout",
            "level": "DEBUG"
        }
    },
    formatters={
        "simple": {
            "format": "%(asctime)s[%(name)s(line:%(lineno)d)%(levelname)s] %(message)s",
            'datefmt': "%H:%M:%S"
        }
    },
    root={
        "handlers": ["console"],
        "propagate": False,
        "level": "WARN"
    },
    loggers={
        "sanic": {
            "handlers": ["console"],
            "propagate": False,
            "level": "WARN"
        }
    }


)

logging.config.dictConfig(log_config)
logger = logging.getLogger("root")

app = Sanic(__name__)


@app.get("/")
def index(request):
    return text("Hello World")


app.run(port=8091)
```
The log:

```
[2018-01-19 17:57:45 +0800] - (sanic.access)[INFO][127.0.0.1:51268]: GET http://127.0.0.1:8091/  200 11
17:57:45[sanic.access(line:330)INFO] 
```