### PR TITLE
Install Python 3.5 and 3.6 on docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM python:3.6
-
-ADD . /app
-WORKDIR /app
-
-RUN pip install tox

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 test:
 	find . -name "*.pyc" -delete
-	docker build -t sanic/test-image .
+	docker build -t sanic/test-image -f docker/Dockerfile .
 	docker run -t sanic/test-image tox

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache --update \
+        curl \
+        bash \
+        build-base \
+        ca-certificates \
+        git \
+        bzip2-dev \
+        linux-headers \
+        ncurses-dev \
+        openssl \
+        openssl-dev \
+        readline-dev \
+        sqlite-dev
+
+RUN update-ca-certificates
+RUN rm -rf /var/cache/apk/*
+
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+
+ADD . /app
+WORKDIR /app
+
+RUN /app/docker/bin/install_python.sh 3.5.4 3.6.4
+
+ENTRYPOINT ["./docker/bin/entrypoint.sh"]

--- a/docker/bin/entrypoint.sh
+++ b/docker/bin/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+source /root/.pyenv/completions/pyenv.bash
+
+pip install tox
+
+exec $@
+

--- a/docker/bin/install_python.sh
+++ b/docker/bin/install_python.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+export CFLAGS='-O2'
+export EXTRA_CFLAGS="-DTHREAD_STACK_SIZE=0x100000"
+
+curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+eval "$(pyenv init -)"
+
+for ver in $@
+do
+    pyenv install $ver
+done
+
+pyenv global $@
+pip install --upgrade pip
+pyenv rehash


### PR DESCRIPTION
Currently docker component in the project will just pass the test suite on Python 3.6. In this commit, I've used [pyenv](https://github.com/pyenv/pyenv) to efficiently manage multiple versions of Python on an Alpine container (which reduces the download size of the base container and allows to cover more versions -looks like the download size was a matter of [concern](https://github.com/channelcat/sanic/pull/604#pullrequestreview-29628030)-). 