### PR TITLE
KeepAlive Timeout log level change to debug

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -195,7 +195,7 @@ class HttpProtocol(asyncio.Protocol):
                                      self.keep_alive_timeout_callback)
             )
         else:
-            logger.info('KeepAlive Timeout. Closing connection.')
+            logger.debug('KeepAlive Timeout. Closing connection.')
             self.transport.close()
             self.transport = None
 


### PR DESCRIPTION
As discussed in [this thread](https://github.com/channelcat/sanic/issues/1093), I just made the logging change from `INFO` to `DEBUG` level when the Keep Alive Times out.

FYI @ashleysommer 