### PR TITLE
Pin pytest version to 3.3.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ beautifulsoup4
 coverage
 httptools
 flake8
-pytest
+pytest==3.3.2
 tox
 ujson
 uvloop

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
     {py35,py36}-no-ext: SANIC_NO_UVLOOP=1
 deps =
     coverage
-    pytest
+    pytest==3.3.2
     pytest-cov
     pytest-sanic
     pytest-sugar


### PR DESCRIPTION
Test are failing with `pytest==3.4.0` due to https://github.com/pytest-dev/pytest/issues/3170, so this PR pins version of it.