### PR TITLE
fixed bug in multipart/form-data parser

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -312,8 +312,9 @@ def parse_multipart_form(body, boundary):
         if field_name:
             post_data = form_part[line_index:-4]
             if file_name:
-                form_file = \
-                    File(type=content_type, name=file_name, body=post_data)
+                form_file = File(type=content_type,
+                                 name=file_name,
+                                 body=post_data)
                 if field_name in files:
                     files[field_name].append(form_file)
                 else:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -312,11 +312,11 @@ def parse_multipart_form(body, boundary):
         if field_name:
             post_data = form_part[line_index:-4]
             if file_name:
-                file = File(type=content_type, name=file_name, body=post_data)
+                form_file = File(type=content_type, name=file_name, body=post_data)
                 if field_name in files:
-                    files[field_name].append(file)
+                    files[field_name].append(form_file)
                 else:
-                    files[field_name] = [file]
+                    files[field_name] = [form_file]
             else:
                 value = post_data.decode(content_charset)
                 if field_name in fields:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -312,7 +312,8 @@ def parse_multipart_form(body, boundary):
         if field_name:
             post_data = form_part[line_index:-4]
             if file_name:
-                form_file = File(type=content_type, name=file_name, body=post_data)
+                form_file = \
+                    File(type=content_type, name=file_name, body=post_data)
                 if field_name in files:
                     files[field_name].append(form_file)
                 else:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -284,7 +284,8 @@ def parse_multipart_form(body, boundary):
     form_parts = body.split(boundary)
     for form_part in form_parts[1:-1]:
         file_name = None
-        file_type = None
+        content_type = "text/plain"
+        content_charset = "utf-8"
         field_name = None
         line_index = 2
         line_end_index = 0
@@ -304,19 +305,21 @@ def parse_multipart_form(body, boundary):
             if form_header_field == 'content-disposition':
                 if 'filename' in form_parameters:
                     file_name = form_parameters['filename']
-                field_name = form_parameters.get('name')
+                field_name = form_parameters['name']
             elif form_header_field == 'content-type':
-                file_type = form_header_value
+                content_type = form_header_value
+                if 'charset' in form_parameters:
+                    content_charset = form_parameters['charset']
 
         post_data = form_part[line_index:-4]
-        if file_name or file_type:
-            file = File(type=file_type, name=file_name, body=post_data)
+        if file_name:
+            file = File(type=content_type, name=file_name, body=post_data)
             if field_name in files:
                 files[field_name].append(file)
             else:
                 files[field_name] = [file]
         else:
-            value = post_data.decode('utf-8')
+            value = post_data.decode(content_charset)
             if field_name in fields:
                 fields[field_name].append(value)
             else:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -303,13 +303,11 @@ def parse_multipart_form(body, boundary):
                 form_line[colon_index + 2:])
 
             if form_header_field == 'content-disposition':
-                if 'filename' in form_parameters:
-                    file_name = form_parameters['filename']
-                field_name = form_parameters['name']
+                file_name = form_parameters.get('filename')
+                field_name = form_parameters.get('name')
             elif form_header_field == 'content-type':
                 content_type = form_header_value
-                if 'charset' in form_parameters:
-                    content_charset = form_parameters['charset']
+                content_charset = form_parameters.get('charset', 'utf-8')
 
         post_data = form_part[line_index:-4]
         if file_name:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -324,6 +324,7 @@ def parse_multipart_form(body, boundary):
                 else:
                     fields[field_name] = [value]
         else:
-            logger.debug('Form-data field does not have a name parameter in the Content-Disposition header')
+            logger.debug('Form-data field does not have a \'name\' parameter \
+                         in the Content-Disposition header')
 
     return fields, files


### PR DESCRIPTION
Sanic automatically assumes that a form field is a file if it has a content-type header, even though the header is text/plain or application/json. This is a fix for it, I took into account the RFC7578 specification regarding the defaults.

This is an improvement of the incorrect fix in PR #869 