### PR TITLE
Issue: 1102 HTTP 204 status code

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -239,7 +239,8 @@ def json(body, status=200, headers=None,
     :param headers: Custom Headers.
     :param kwargs: Remaining arguments that are passed to the json encoder.
     """
-    return HTTPResponse(dumps(body, **kwargs), headers=headers,
+    _body = dumps(body, **kwargs) if body else None
+    return HTTPResponse(_body, headers=headers,
                         status=status, content_type=content_type)
 
 

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -196,11 +196,13 @@ class HTTPResponse(BaseHTTPResponse):
         if keep_alive and keep_alive_timeout is not None:
             timeout_header = b'Keep-Alive: %d\r\n' % keep_alive_timeout
 
+        body = b''
         content_length = 0
         if self.status is not 204:
+            body = self.body
             content_length = self.headers.get('Content-Length', len(self.body))
-        self.headers['Content-Length'] = content_length
 
+        self.headers['Content-Length'] = content_length
         self.headers['Content-Type'] = self.headers.get(
             'Content-Type', self.content_type)
 
@@ -222,7 +224,7 @@ class HTTPResponse(BaseHTTPResponse):
                    b'keep-alive' if keep_alive else b'close',
                    timeout_header,
                    headers,
-                   self.body if self.status is not 204 else b''
+                   body
                )
 
     @property

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -104,6 +104,7 @@ def test_json():
 
     assert results.get('test') == True
 
+
 def test_empty_json():
     app = Sanic('test_json')
 
@@ -114,7 +115,7 @@ def test_empty_json():
 
     request, response = app.test_client.get('/')
     assert response.status == 200
-    assert response.text == ''
+    assert response.text == 'null'
 
 
 def test_invalid_json():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -109,12 +109,13 @@ def test_empty_json():
 
     @app.route('/')
     async def handler(request):
-        assert request.json == None
+        assert request.json is None
         return json(request.json)
 
     request, response = app.test_client.get('/')
     assert response.status == 200
-    assert response.text == 'null'
+    assert response.text == ''
+
 
 def test_invalid_json():
     app = Sanic('test_json')

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -63,8 +63,12 @@ def json_app():
     async def test(request):
         return json(JSON_DATA)
 
+    @app.get("/no-content")
+    async def no_content_handler(request):
+        return json(JSON_DATA, status=204)
+
     @app.delete("/")
-    async def test_delete(request):
+    async def delete_handler(request):
         return json(None, status=204)
 
     return app
@@ -79,6 +83,11 @@ def test_json_response(json_app):
 
 
 def test_no_content(json_app):
+    request, response = json_app.test_client.get('/no-content')
+    assert response.status == 204
+    assert response.text == ''
+    assert response.headers['Content-Length'] == '0'
+
     request, response = json_app.test_client.delete('/')
     assert response.status == 204
     assert response.text == ''

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -43,7 +43,7 @@ def test_method_not_allowed():
         return response.json({'hello': 'world'})
 
     request, response = app.test_client.head('/')
-    assert response.headers['Allow']== 'GET'
+    assert response.headers['Allow'] == 'GET'
 
     @app.post('/')
     async def test(request):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -63,6 +63,10 @@ def json_app():
     async def test(request):
         return json(JSON_DATA)
 
+    @app.delete("/")
+    async def test_delete(request):
+        return json(None, status=204)
+
     return app
 
 
@@ -72,6 +76,14 @@ def test_json_response(json_app):
     assert response.status == 200
     assert response.text == json_dumps(JSON_DATA)
     assert response.json == JSON_DATA
+
+
+def test_no_content(json_app):
+    request, response = json_app.test_client.delete('/')
+    assert response.status == 204
+    assert response.text == ''
+    assert response.headers['Content-Length'] == '0'
+
 
 @pytest.fixture
 def streaming_app():


### PR DESCRIPTION
According to [Issue 1102](https://github.com/channelcat/sanic/issues/1102) this is a proposal as for how the HTTPResponse should behave when returning an HTTP status code 204 (No-Content)

Previous behavior:
- When passing `None` in the json response method with status 204:
    + Returns a Response with content length header length `4`  (from `len('null')`)

Current behavior:
- On HTTP status code 204, no body will be sent and content length header will be set to 0, regardless of the body passed.