### PR TITLE
Content Length header on 204 and 304 responses

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -239,7 +239,8 @@ def json(body, status=200, headers=None,
     :param headers: Custom Headers.
     :param kwargs: Remaining arguments that are passed to the json encoder.
     """
-    return HTTPResponse(dumps(body, **kwargs), headers=headers,
+    _body = dumps(body, **kwargs) if body else None
+    return HTTPResponse(_body, headers=headers,
                         status=status, content_type=content_type)
 
 

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -196,11 +196,13 @@ class HTTPResponse(BaseHTTPResponse):
         if keep_alive and keep_alive_timeout is not None:
             timeout_header = b'Keep-Alive: %d\r\n' % keep_alive_timeout
 
+        body = b''
         content_length = 0
         if self.status is not 204:
+            body = self.body
             content_length = self.headers.get('Content-Length', len(self.body))
-        self.headers['Content-Length'] = content_length
 
+        self.headers['Content-Length'] = content_length
         self.headers['Content-Type'] = self.headers.get(
             'Content-Type', self.content_type)
 
@@ -222,7 +224,7 @@ class HTTPResponse(BaseHTTPResponse):
                    b'keep-alive' if keep_alive else b'close',
                    timeout_header,
                    headers,
-                   self.body if self.status is not 204 else b''
+                   body
                )
 
     @property

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -198,7 +198,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         body = b''
         content_length = 0
-        if self.status is not 204:
+        if self.status is not 204 and self.status != 304:
             body = self.body
             content_length = self.headers.get('Content-Length', len(self.body))
 

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -72,6 +72,8 @@ STATUS_CODES = {
     511: b'Network Authentication Required'
 }
 
+EMPTY_STATUS_CODES = [204, 304]
+
 
 class BaseHTTPResponse:
     def _encode_body(self, data):
@@ -198,7 +200,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         body = b''
         content_length = 0
-        if self.status is not 204 and self.status != 304:
+        if self.status not in EMPTY_STATUS_CODES:
             body = self.body
             content_length = self.headers.get('Content-Length', len(self.body))
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -104,6 +104,7 @@ def test_json():
 
     assert results.get('test') == True
 
+
 def test_empty_json():
     app = Sanic('test_json')
 
@@ -114,7 +115,7 @@ def test_empty_json():
 
     request, response = app.test_client.get('/')
     assert response.status == 200
-    assert response.text == ''
+    assert response.text == 'null'
 
 
 def test_invalid_json():

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -109,12 +109,13 @@ def test_empty_json():
 
     @app.route('/')
     async def handler(request):
-        assert request.json == None
+        assert request.json is None
         return json(request.json)
 
     request, response = app.test_client.get('/')
     assert response.status == 200
-    assert response.text == 'null'
+    assert response.text == ''
+
 
 def test_invalid_json():
     app = Sanic('test_json')

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock
 JSON_DATA = {'ok': True}
 
 
-
 def test_response_body_not_a_string():
     """Test when a response body sent from the application is not a string"""
     app = Sanic('response_body_not_a_string')
@@ -34,6 +33,7 @@ async def sample_streaming_fn(response):
     response.write('foo,')
     await asyncio.sleep(.001)
     response.write('bar')
+
 
 def test_method_not_allowed():
     app = Sanic('method_not_allowed')
@@ -195,9 +195,11 @@ def get_file_content(static_file_directory, file_name):
     with open(os.path.join(static_file_directory, file_name), 'rb') as file:
         return file.read()
 
+
 @pytest.mark.parametrize('file_name', ['test.file', 'decode me.txt', 'python.png'])
 def test_file_response(file_name, static_file_directory):
     app = Sanic('test_file_helper')
+
     @app.route('/files/<filename>', methods=['GET'])
     def file_route(request, filename):
         file_path = os.path.join(static_file_directory, filename)
@@ -209,10 +211,12 @@ def test_file_response(file_name, static_file_directory):
     assert response.body == get_file_content(static_file_directory, file_name)
     assert 'Content-Disposition' not in response.headers
 
+
 @pytest.mark.parametrize('source,dest', [
     ('test.file', 'my_file.txt'), ('decode me.txt', 'readme.md'), ('python.png', 'logo.png')])
 def test_file_response_custom_filename(source, dest, static_file_directory):
     app = Sanic('test_file_helper')
+
     @app.route('/files/<filename>', methods=['GET'])
     def file_route(request, filename):
         file_path = os.path.join(static_file_directory, filename)
@@ -224,9 +228,11 @@ def test_file_response_custom_filename(source, dest, static_file_directory):
     assert response.body == get_file_content(static_file_directory, source)
     assert response.headers['Content-Disposition'] == 'attachment; filename="{}"'.format(dest)
 
+
 @pytest.mark.parametrize('file_name', ['test.file', 'decode me.txt'])
 def test_file_head_response(file_name, static_file_directory):
     app = Sanic('test_file_helper')
+
     @app.route('/files/<filename>', methods=['GET', 'HEAD'])
     async def file_route(request, filename):
         file_path = os.path.join(static_file_directory, filename)
@@ -251,25 +257,29 @@ def test_file_head_response(file_name, static_file_directory):
                'Content-Length']) == len(
                    get_file_content(static_file_directory, file_name))
 
+
 @pytest.mark.parametrize('file_name', ['test.file', 'decode me.txt', 'python.png'])
 def test_file_stream_response(file_name, static_file_directory):
     app = Sanic('test_file_helper')
+
     @app.route('/files/<filename>', methods=['GET'])
     def file_route(request, filename):
         file_path = os.path.join(static_file_directory, filename)
         file_path = os.path.abspath(unquote(file_path))
         return file_stream(file_path, chunk_size=32,
-                          mime_type=guess_type(file_path)[0] or 'text/plain')
+                           mime_type=guess_type(file_path)[0] or 'text/plain')
 
     request, response = app.test_client.get('/files/{}'.format(file_name))
     assert response.status == 200
     assert response.body == get_file_content(static_file_directory, file_name)
     assert 'Content-Disposition' not in response.headers
 
+
 @pytest.mark.parametrize('source,dest', [
     ('test.file', 'my_file.txt'), ('decode me.txt', 'readme.md'), ('python.png', 'logo.png')])
 def test_file_stream_response_custom_filename(source, dest, static_file_directory):
     app = Sanic('test_file_helper')
+
     @app.route('/files/<filename>', methods=['GET'])
     def file_route(request, filename):
         file_path = os.path.join(static_file_directory, filename)
@@ -281,9 +291,11 @@ def test_file_stream_response_custom_filename(source, dest, static_file_director
     assert response.body == get_file_content(static_file_directory, source)
     assert response.headers['Content-Disposition'] == 'attachment; filename="{}"'.format(dest)
 
+
 @pytest.mark.parametrize('file_name', ['test.file', 'decode me.txt'])
 def test_file_stream_head_response(file_name, static_file_directory):
     app = Sanic('test_file_helper')
+
     @app.route('/files/<filename>', methods=['GET', 'HEAD'])
     async def file_route(request, filename):
         file_path = os.path.join(static_file_directory, filename)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -63,8 +63,12 @@ def json_app():
     async def test(request):
         return json(JSON_DATA)
 
+    @app.get("/no-content")
+    async def no_content_handler(request):
+        return json(JSON_DATA, status=204)
+
     @app.delete("/")
-    async def test_delete(request):
+    async def delete_handler(request):
         return json(None, status=204)
 
     return app
@@ -79,6 +83,11 @@ def test_json_response(json_app):
 
 
 def test_no_content(json_app):
+    request, response = json_app.test_client.get('/no-content')
+    assert response.status == 204
+    assert response.text == ''
+    assert response.headers['Content-Length'] == '0'
+
     request, response = json_app.test_client.delete('/')
     assert response.status == 204
     assert response.text == ''

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -67,6 +67,14 @@ def json_app():
     async def no_content_handler(request):
         return json(JSON_DATA, status=204)
 
+    @app.get("/no-content/unmodified")
+    async def no_content_unmodified_handler(request):
+        return json(None, status=304)
+
+    @app.get("/unmodified")
+    async def unmodified_handler(request):
+        return json(JSON_DATA, status=304)
+
     @app.delete("/")
     async def delete_handler(request):
         return json(None, status=204)
@@ -85,6 +93,16 @@ def test_json_response(json_app):
 def test_no_content(json_app):
     request, response = json_app.test_client.get('/no-content')
     assert response.status == 204
+    assert response.text == ''
+    assert response.headers['Content-Length'] == '0'
+
+    request, response = json_app.test_client.get('/no-content/unmodified')
+    assert response.status == 304
+    assert response.text == ''
+    assert response.headers['Content-Length'] == '0'
+
+    request, response = json_app.test_client.get('/unmodified')
+    assert response.status == 304
     assert response.text == ''
     assert response.headers['Content-Length'] == '0'
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -312,7 +312,7 @@ def test_file_stream_head_response(file_name, static_file_directory):
                 content_type=guess_type(file_path)[0] or 'text/plain')
         else:
             return file_stream(file_path, chunk_size=32, headers=headers,
-                        mime_type=guess_type(file_path)[0] or 'text/plain')
+                               mime_type=guess_type(file_path)[0] or 'text/plain')
 
     request, response = app.test_client.head('/files/{}'.format(file_name))
     assert response.status == 200

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -43,7 +43,7 @@ def test_method_not_allowed():
         return response.json({'hello': 'world'})
 
     request, response = app.test_client.head('/')
-    assert response.headers['Allow']== 'GET'
+    assert response.headers['Allow'] == 'GET'
 
     @app.post('/')
     async def test(request):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -63,6 +63,10 @@ def json_app():
     async def test(request):
         return json(JSON_DATA)
 
+    @app.delete("/")
+    async def test_delete(request):
+        return json(None, status=204)
+
     return app
 
 
@@ -72,6 +76,14 @@ def test_json_response(json_app):
     assert response.status == 200
     assert response.text == json_dumps(JSON_DATA)
     assert response.json == JSON_DATA
+
+
+def test_no_content(json_app):
+    request, response = json_app.test_client.delete('/')
+    assert response.status == 204
+    assert response.text == ''
+    assert response.headers['Content-Length'] == '0'
+
 
 @pytest.fixture
 def streaming_app():


### PR DESCRIPTION
## Issues
According to [Issue 1102](https://github.com/channelcat/sanic/issues/1102) this is a proposal as for how the HTTPResponse should behave when returning an HTTP status code 204 (No-Content)
According to [Issue 728](https://github.com/channelcat/sanic/issues/728) this is a proposal as for how the HTTPResponse should behave when returning an HTTP status code 304 (Not-Modified)

## Reference
[Reference for 1102](https://tools.ietf.org/html/rfc2616#section-10.2.5)
[Reference for 728](https://tools.ietf.org/html/rfc2616#section-10.3.5)

## Behavior
Previous behavior:
- When passing `None` in the json response method with status 204:
    + Returns a Response with content length header length `4`  (from `len('null')`)
- When returning a Response status code 304 with or without body:
    + Returns content length header of length `> 0`

Current behavior:
- On HTTP status code 204, no body will be sent and content length header will be set to 0, regardless of the body passed.
- On HTTP status code 304, no body will be sent and content length header will be set to 0, regardless of the body passed.


### Note
This PR substitutes [PR 1110](https://github.com/channelcat/sanic/pull/1110)