### PR TITLE
Fixed bug when passing a list into route decorator's host argument #1120

### DIFF
--- a/sanic/router.py
+++ b/sanic/router.py
@@ -128,6 +128,13 @@ class Router:
         if strict_slashes:
             return
 
+        if not isinstance(host, str) and host is not None:
+            # we have gotten back to the top of the recursion tree where the
+            # host was originally a list. By now, we've processed the strict
+            # slashes logic on the leaf nodes (the individual host strings in
+            # the list of host)
+            return
+
         # Add versions with and without trailing /
         slashed_methods = self.routes_all.get(uri + '/', frozenset({}))
         unslashed_methods = self.routes_all.get(uri[:-1], frozenset({}))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -174,6 +174,40 @@ def test_route_optional_slash():
     request, response = app.test_client.get('/get/')
     assert response.text == 'OK'
 
+def test_route_strict_slashes_set_to_false_and_host_is_a_list():
+    #Part of regression test for issue #1120
+    app = Sanic('test_route_strict_slashes_set_to_false_and_host_is_a_list')
+
+    site1 = 'localhost:{}'.format(app.test_client.port)
+
+    #before fix, this raises a RouteExists error
+    @app.get('/get', host=[site1, 'site2.com'], strict_slashes=False)
+    def handler(request):
+        return text('OK')
+
+    request, response = app.test_client.get('http://' + site1 + '/get')
+    assert response.text == 'OK'
+
+    @app.post('/post', host=[site1, 'site2.com'], strict_slashes=False)
+    def handler(request):
+        return text('OK')
+
+    request, response = app.test_client.post('http://' + site1 +'/post')
+    assert response.text == 'OK'
+
+    @app.put('/put', host=[site1, 'site2.com'], strict_slashes=False)
+    def handler(request):
+        return text('OK')
+
+    request, response = app.test_client.put('http://' + site1 +'/put')
+    assert response.text == 'OK'
+
+    @app.delete('/delete', host=[site1, 'site2.com'], strict_slashes=False)
+    def handler(request):
+        return text('OK')
+
+    request, response = app.test_client.delete('http://' + site1 +'/delete')
+    assert response.text == 'OK'
 
 def test_shorthand_routes_post():
     app = Sanic('test_shorhand_routes_post')


### PR DESCRIPTION
Fixing #1120 
There happens to be a bug in a recursive call to `Router._add` that tries to apply the `strip slashes`  logic wrongly. Normally when the host param passed to `Router._add` is a string, the method runs smoothly (the easy, good case). However, setting host to a list like 

```python
@app.route('/post', methods=['POST'], host=['test.com', 'test2.com'])
def handler():
    return text('OK')
```

triggers a recursive call to Router._add. More details are stated in the commit message.