### PR TITLE
HTTP Entity Headers

### DIFF
--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -1,4 +1,4 @@
-from sanic.response import STATUS_CODES
+from sanic.http import STATUS_CODES
 
 TRACEBACK_STYLE = '''
     <style>

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -62,8 +62,6 @@ STATUS_CODES = {
     511: b'Network Authentication Required'
 }
 
-EMPTY_STATUS_CODES = [204, 304]
-
 # According to https://tools.ietf.org/html/rfc2616#section-7.1
 _ENTITY_HEADERS = frozenset([
     b'allow',
@@ -92,6 +90,16 @@ _HOP_BY_HOP_HEADERS = frozenset([
 ])
 
 
+def has_message_body(status):
+    """
+    According to the following RFC message body and length SHOULD NOT be included
+    in responses status 1XX, 204 and 304.
+    https://tools.ietf.org/html/rfc2616#section-4.4
+    https://tools.ietf.org/html/rfc2616#section-4.3
+    """
+    return status not in [204, 304] and not (100 <= status < 200)
+
+
 def is_entity_header(header):
     """Checks if the given header is an Entity Header"""
     return header.lower() in _ENTITY_HEADERS
@@ -107,20 +115,20 @@ def remove_entity_headers(headers,
     """
     Removes all the entity headers present in the headers given.
     According to RFC 2616 Section 10.3.5,
-    Content-Location and Expires should be included
-    https://tools.ietf.org/html/rfc2616#section-10.3.5
+    Content-Location and Expires should be included as for the
+    "strong cache validator" in https://tools.ietf.org/html/rfc2616#section-10.3.5
 
     returns the headers without the entity headers
     """
-    allowed = set([h.lower() for h in headers])
-    headers[:] = [(header, value) for header, value in headers
-                  if not is_entity_header(header)
-                  and header.lower() not in allowed]
+    allowed = set([h.lower() for h in allowed])
+    headers = {header: value for header, value in headers.items()
+               if not is_entity_header(header)
+               and header.lower() not in allowed}
     return headers
 
 
 def remove_hop_by_hop_headers(headers):
     """Removes the Hop By Hop Headers."""
-    headers[:] = [(header, value) for header, value in headers
-                  if not is_hop_by_hop_header(header)]
+    headers = {header: value for header, value in headers.items()
+               if not is_hop_by_hop_header(header)}
     return headers

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -1,0 +1,126 @@
+"""Defines basics of HTTP standard."""
+
+STATUS_CODES = {
+    100: b'Continue',
+    101: b'Switching Protocols',
+    102: b'Processing',
+    200: b'OK',
+    201: b'Created',
+    202: b'Accepted',
+    203: b'Non-Authoritative Information',
+    204: b'No Content',
+    205: b'Reset Content',
+    206: b'Partial Content',
+    207: b'Multi-Status',
+    208: b'Already Reported',
+    226: b'IM Used',
+    300: b'Multiple Choices',
+    301: b'Moved Permanently',
+    302: b'Found',
+    303: b'See Other',
+    304: b'Not Modified',
+    305: b'Use Proxy',
+    307: b'Temporary Redirect',
+    308: b'Permanent Redirect',
+    400: b'Bad Request',
+    401: b'Unauthorized',
+    402: b'Payment Required',
+    403: b'Forbidden',
+    404: b'Not Found',
+    405: b'Method Not Allowed',
+    406: b'Not Acceptable',
+    407: b'Proxy Authentication Required',
+    408: b'Request Timeout',
+    409: b'Conflict',
+    410: b'Gone',
+    411: b'Length Required',
+    412: b'Precondition Failed',
+    413: b'Request Entity Too Large',
+    414: b'Request-URI Too Long',
+    415: b'Unsupported Media Type',
+    416: b'Requested Range Not Satisfiable',
+    417: b'Expectation Failed',
+    418: b'I\'m a teapot',
+    422: b'Unprocessable Entity',
+    423: b'Locked',
+    424: b'Failed Dependency',
+    426: b'Upgrade Required',
+    428: b'Precondition Required',
+    429: b'Too Many Requests',
+    431: b'Request Header Fields Too Large',
+    451: b'Unavailable For Legal Reasons',
+    500: b'Internal Server Error',
+    501: b'Not Implemented',
+    502: b'Bad Gateway',
+    503: b'Service Unavailable',
+    504: b'Gateway Timeout',
+    505: b'HTTP Version Not Supported',
+    506: b'Variant Also Negotiates',
+    507: b'Insufficient Storage',
+    508: b'Loop Detected',
+    510: b'Not Extended',
+    511: b'Network Authentication Required'
+}
+
+EMPTY_STATUS_CODES = [204, 304]
+
+# According to https://tools.ietf.org/html/rfc2616#section-7.1
+_ENTITY_HEADERS = frozenset([
+    b'allow',
+    b'content-encoding',
+    b'content-language',
+    b'content-length',
+    b'content-location',
+    b'content-md5',
+    b'content-range',
+    b'content-type',
+    b'expires',
+    b'last-modified',
+    b'extension-header'
+])
+
+# According to https://tools.ietf.org/html/rfc2616#section-13.5.1
+_HOP_BY_HOP_HEADERS = frozenset([
+    b'connection',
+    b'keep-alive',
+    b'proxy-authenticate',
+    b'proxy-authorization',
+    b'te',
+    b'trailers',
+    b'transfer-encoding',
+    b'upgrade'
+])
+
+
+def is_entity_header(header):
+    """Checks if the given header is an Entity Header"""
+    return header.lower() in _ENTITY_HEADERS
+
+
+def is_hop_by_hop_header(header):
+    """Checks if the given header is a Hop By Hop header"""
+    return header.lower() in _HOP_BY_HOP_HEADERS
+
+
+def remove_entity_headers(headers,
+                          allowed=(b'content-location', b'expires')):
+    """
+    Removes all the entity headers present in the headers given.
+    According to RFC 2616 Section 10.3.5,
+    Content-Location and Expires should be included
+    https://tools.ietf.org/html/rfc2616#section-10.3.5
+
+    returns the headers without the entity headers
+    """
+    allowed = set([h.lower() for h in headers])
+    headers[:] = [(header, value) for header, value in headers
+                  if not is_entity_header(header)
+                  and header.lower() not in allowed]
+    return headers
+
+
+def remove_hop_by_hop_headers(headers):
+    """Removes the Hop By Hop Headers."""
+    headers[:] = [(header, value) for header, value in headers
+                  if not is_hop_by_hop_header(header)]
+    return headers

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -64,29 +64,29 @@ STATUS_CODES = {
 
 # According to https://tools.ietf.org/html/rfc2616#section-7.1
 _ENTITY_HEADERS = frozenset([
-    b'allow',
-    b'content-encoding',
-    b'content-language',
-    b'content-length',
-    b'content-location',
-    b'content-md5',
-    b'content-range',
-    b'content-type',
-    b'expires',
-    b'last-modified',
-    b'extension-header'
+    'allow',
+    'content-encoding',
+    'content-language',
+    'content-length',
+    'content-location',
+    'content-md5',
+    'content-range',
+    'content-type',
+    'expires',
+    'last-modified',
+    'extension-header'
 ])
 
 # According to https://tools.ietf.org/html/rfc2616#section-13.5.1
 _HOP_BY_HOP_HEADERS = frozenset([
-    b'connection',
-    b'keep-alive',
-    b'proxy-authenticate',
-    b'proxy-authorization',
-    b'te',
-    b'trailers',
-    b'transfer-encoding',
-    b'upgrade'
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailers',
+    'transfer-encoding',
+    'upgrade'
 ])
 
 
@@ -111,7 +111,7 @@ def is_hop_by_hop_header(header):
 
 
 def remove_entity_headers(headers,
-                          allowed=(b'content-location', b'expires')):
+                          allowed=('content-location', 'expires')):
     """
     Removes all the entity headers present in the headers given.
     According to RFC 2616 Section 10.3.5,

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -92,8 +92,8 @@ _HOP_BY_HOP_HEADERS = frozenset([
 
 def has_message_body(status):
     """
-    According to the following RFC message body and length SHOULD NOT be included
-    in responses status 1XX, 204 and 304.
+    According to the following RFC message body and length SHOULD NOT
+    be included in responses status 1XX, 204 and 304.
     https://tools.ietf.org/html/rfc2616#section-4.4
     https://tools.ietf.org/html/rfc2616#section-4.3
     """
@@ -115,8 +115,9 @@ def remove_entity_headers(headers,
     """
     Removes all the entity headers present in the headers given.
     According to RFC 2616 Section 10.3.5,
-    Content-Location and Expires should be included as for the
-    "strong cache validator" in https://tools.ietf.org/html/rfc2616#section-10.3.5
+    Content-Location and Expires are allowed as for the
+    "strong cache validator".
+    https://tools.ietf.org/html/rfc2616#section-10.3.5
 
     returns the headers without the entity headers
     """

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -126,10 +126,3 @@ def remove_entity_headers(headers,
                if not is_entity_header(header)
                and header.lower() not in allowed}
     return headers
-
-
-def remove_hop_by_hop_headers(headers):
-    """Removes the Hop By Hop Headers."""
-    headers = {header: value for header, value in headers.items()
-               if not is_hop_by_hop_header(header)}
-    return headers

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -8,71 +8,8 @@ except BaseException:
 
 from aiofiles import open as open_async
 
+from sanic.http import STATUS_CODES, EMPTY_STATUS_CODES
 from sanic.cookies import CookieJar
-
-STATUS_CODES = {
-    100: b'Continue',
-    101: b'Switching Protocols',
-    102: b'Processing',
-    200: b'OK',
-    201: b'Created',
-    202: b'Accepted',
-    203: b'Non-Authoritative Information',
-    204: b'No Content',
-    205: b'Reset Content',
-    206: b'Partial Content',
-    207: b'Multi-Status',
-    208: b'Already Reported',
-    226: b'IM Used',
-    300: b'Multiple Choices',
-    301: b'Moved Permanently',
-    302: b'Found',
-    303: b'See Other',
-    304: b'Not Modified',
-    305: b'Use Proxy',
-    307: b'Temporary Redirect',
-    308: b'Permanent Redirect',
-    400: b'Bad Request',
-    401: b'Unauthorized',
-    402: b'Payment Required',
-    403: b'Forbidden',
-    404: b'Not Found',
-    405: b'Method Not Allowed',
-    406: b'Not Acceptable',
-    407: b'Proxy Authentication Required',
-    408: b'Request Timeout',
-    409: b'Conflict',
-    410: b'Gone',
-    411: b'Length Required',
-    412: b'Precondition Failed',
-    413: b'Request Entity Too Large',
-    414: b'Request-URI Too Long',
-    415: b'Unsupported Media Type',
-    416: b'Requested Range Not Satisfiable',
-    417: b'Expectation Failed',
-    418: b'I\'m a teapot',
-    422: b'Unprocessable Entity',
-    423: b'Locked',
-    424: b'Failed Dependency',
-    426: b'Upgrade Required',
-    428: b'Precondition Required',
-    429: b'Too Many Requests',
-    431: b'Request Header Fields Too Large',
-    451: b'Unavailable For Legal Reasons',
-    500: b'Internal Server Error',
-    501: b'Not Implemented',
-    502: b'Bad Gateway',
-    503: b'Service Unavailable',
-    504: b'Gateway Timeout',
-    505: b'HTTP Version Not Supported',
-    506: b'Variant Also Negotiates',
-    507: b'Insufficient Storage',
-    508: b'Loop Detected',
-    510: b'Not Extended',
-    511: b'Network Authentication Required'
-}
-
-EMPTY_STATUS_CODES = [204, 304]
 
 
 class BaseHTTPResponse:

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -138,7 +138,8 @@ class HTTPResponse(BaseHTTPResponse):
         body = b''
         if http.has_message_body(self.status):
             body = self.body
-            self.headers['Content-Length'] = self.headers.get('Content-Length', len(self.body))
+            self.headers['Content-Length'] = self.headers.get(
+                'Content-Length', len(self.body))
 
         self.headers['Content-Type'] = self.headers.get(
                                        'Content-Type', self.content_type)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -94,22 +94,22 @@ def test_no_content(json_app):
     request, response = json_app.test_client.get('/no-content')
     assert response.status == 204
     assert response.text == ''
-    assert response.headers['Content-Length'] == '0'
+    assert 'Content-Length' not in response.headers
 
     request, response = json_app.test_client.get('/no-content/unmodified')
     assert response.status == 304
     assert response.text == ''
-    assert response.headers['Content-Length'] == '0'
+    assert 'Content-Length' not in response.headers
 
     request, response = json_app.test_client.get('/unmodified')
     assert response.status == 304
     assert response.text == ''
-    assert response.headers['Content-Length'] == '0'
+    assert 'Content-Length' not in response.headers
 
     request, response = json_app.test_client.delete('/')
     assert response.status == 204
     assert response.text == ''
-    assert response.headers['Content-Length'] == '0'
+    assert 'Content-Length' not in response.headers
 
 
 @pytest.fixture

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -9,6 +9,7 @@ import pytest
 from random import choice
 
 from sanic import Sanic
+from sanic.http import is_entity_header
 from sanic.response import HTTPResponse, stream, StreamingHTTPResponse, file, file_stream, json
 from sanic.testing import HOST
 from unittest.mock import MagicMock
@@ -100,6 +101,8 @@ def test_no_content(json_app):
     assert response.status == 304
     assert response.text == ''
     assert 'Content-Length' not in response.headers
+    for header in response.headers:
+        assert not is_entity_header(header)
 
     request, response = json_app.test_client.get('/unmodified')
     assert response.status == 304

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -9,7 +9,6 @@ import pytest
 from random import choice
 
 from sanic import Sanic
-from sanic.http import is_entity_header
 from sanic.response import HTTPResponse, stream, StreamingHTTPResponse, file, file_stream, json
 from sanic.testing import HOST
 from unittest.mock import MagicMock
@@ -101,13 +100,13 @@ def test_no_content(json_app):
     assert response.status == 304
     assert response.text == ''
     assert 'Content-Length' not in response.headers
-    for header in response.headers:
-        assert not is_entity_header(header)
+    assert 'Content-Type' not in response.headers
 
     request, response = json_app.test_client.get('/unmodified')
     assert response.status == 304
     assert response.text == ''
     assert 'Content-Length' not in response.headers
+    assert 'Content-Type' not in response.headers
 
     request, response = json_app.test_client.delete('/')
     assert response.status == 204


### PR DESCRIPTION
According to [Issue 728](https://github.com/channelcat/sanic/issues/728)

## Previous behavior
- HTTP Entity Header is emitted in status 304
- HTTP 412 sends some Entity headers
- HTTP responses `(100 <= status < 200)` emit message body and length on some, if not all, responses.

## Current behavior
- HTTP status 304 does not emit any entity header, but allowing `Content-Location` and `Expires`.
- HTTP 412 does not emit any entity headers
- HTTP responses with status `(100 <= status < 200)` do not emit message body or length (unless explicitly passed)

## References
- [RFC-2616](https://tools.ietf.org/html/rfc2616)
    + Section 4.3
    + Section 4.4
    + Section 7.1
    + Section 10.3.5
    + Section 13.5.1