### PR TITLE
raw requires a bytes-like object

### DIFF
--- a/docs/sanic/response.md
+++ b/docs/sanic/response.md
@@ -91,7 +91,7 @@ from sanic import response
 
 @app.route('/raw')
 def handle_request(request):
-    return response.raw('raw data')
+    return response.raw(b'raw data')
 ```
 
 ## Modify headers or status


### PR DESCRIPTION
 raw requires a bytes-like object, or an object that implements __bytes__, not 'str'