### PR TITLE
Add __weakref__ to Request slots

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -48,7 +48,7 @@ class Request(dict):
         'app', 'headers', 'version', 'method', '_cookies', 'transport',
         'body', 'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
         '_ip', '_parsed_url', 'uri_template', 'stream', '_remote_addr',
-        '_socket', '_port'
+        '_socket', '_port', '__weakref__'
     )
 
     def __init__(self, url_bytes, headers, version, method, transport):


### PR DESCRIPTION
Sometimes we need to keep weak reference to Request object. The absence of ```__weakref__``` in slots makes Request object incompatible with weakref.ref and weakref.proxy functions.