### PR TITLE
Fix failing tests when aiohttp>=3.1.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 aiofiles
-aiohttp==1.3.5
+aiohttp>=2.3.0
 chardet<=2.3.0
 beautifulsoup4
 coverage

--- a/tests/test_request_timeout.py
+++ b/tests/test_request_timeout.py
@@ -58,18 +58,36 @@ class DelayableTCPConnector(TCPConnector):
             t = req.loop.time()
             print("sending at {}".format(t), flush=True)
             conn = next(iter(args)) # first arg is connection
-            try:
-                delayed_resp = self.orig_send(*args, **kwargs)
-            except Exception as e:
-                return aiohttp.ClientResponse(req.method, req.url)
+            if aiohttp.__version__ >= "3.1.0":
+                try:
+                    delayed_resp = await self.orig_send(*args, **kwargs)
+                except Exception as e:
+                    return aiohttp.ClientResponse(req.method, req.url,
+                        writer=None, continue100=None, timer=None,
+                        request_info=None, auto_decompress=None, traces=[],
+                        loop=req.loop, session=None)
+            else:
+                try:
+                    delayed_resp = self.orig_send(*args, **kwargs)
+                except Exception as e:
+                    return aiohttp.ClientResponse(req.method, req.url)
             return delayed_resp
 
-        def send(self, *args, **kwargs):
-            gen = self.delayed_send(*args, **kwargs)
-            task = self.req.loop.create_task(gen)
-            self.send_task = task
-            self._acting_as = task
-            return self
+        if aiohttp.__version__ >= "3.1.0":
+            # aiohttp changed the request.send method to async
+            async def send(self, *args, **kwargs):
+                gen = self.delayed_send(*args, **kwargs)
+                task = self.req.loop.create_task(gen)
+                self.send_task = task
+                self._acting_as = task
+                return self
+        else:
+            def send(self, *args, **kwargs):
+                gen = self.delayed_send(*args, **kwargs)
+                task = self.req.loop.create_task(gen)
+                self.send_task = task
+                self._acting_as = task
+                return self
 
     def __init__(self, *args, **kwargs):
         _post_connect_delay = kwargs.pop('post_connect_delay', 0)


### PR DESCRIPTION
Some of the tests in Sanic (test_request_timout, test_response_timeout, test_keep_alive_timeout) use a custom SanicClient with modified methods. This relies on overriding internal aiohttp Client class methods.

In aiohttp 3.1.0 there were some breaking changes that caused the custom methods to be no longer compatible with latest upstream aiohttp Client class.
See: https://github.com/aio-libs/aiohttp/commit/903073283fa85bb3e8bb7568d3832a8fd9c06435
and: https://github.com/aio-libs/aiohttp/commit/b42e0ced4653ff62fa1829941e4f680d712b830a

This commit adds aiohttp version checks to adapt to these changes.