### PR TITLE
Make auto reloader work on Mac

### DIFF
--- a/sanic/reloader_helpers.py
+++ b/sanic/reloader_helpers.py
@@ -55,9 +55,9 @@ def restart_with_reloader():
 
 
 def kill_process_children_unix(pid):
-    """Find and kill child process of a process (maximum two level).
+    """Find and kill child processes of a process (maximum two level).
 
-    :param pid: PID of process (process ID)
+    :param pid: PID of parent process (process ID)
     :return: Nothing
     """
     root_process_path = "/proc/{pid}/task/{pid}/children".format(pid=pid)
@@ -77,13 +77,36 @@ def kill_process_children_unix(pid):
             os.kill(int(_pid), signal.SIGTERM)
 
 
+def kill_process_children_osx(pid):
+    """Find and kill child processes of a process.
+
+    :param pid: PID of parent process (process ID)
+    :return: Nothing
+    """
+    subprocess.run(['pkill', '-P', str(pid)])
+
+
+def kill_process_children(pid):
+    """Find and kill child processes of a process.
+
+    :param pid: PID of parent process (process ID)
+    :return: Nothing
+    """
+    if sys.platform == 'darwin':
+        kill_process_children_osx(pid)
+    elif sys.platform == 'posix':
+        kill_process_children_unix(pid)
+    else:
+        pass                    # should signal error here
+
+
 def kill_program_completly(proc):
     """Kill worker and it's child processes and exit.
 
     :param proc: worker process (process ID)
     :return: Nothing
     """
-    kill_process_children_unix(proc.pid)
+    kill_process_children(proc.pid)
     proc.terminate()
     os._exit(0)
 
@@ -112,7 +135,7 @@ def watchdog(sleep_interval):
                 mtimes[filename] = mtime
                 continue
             elif mtime > old_time:
-                kill_process_children_unix(worker_process.pid)
+                kill_process_children(worker_process.pid)
                 worker_process = restart_with_reloader()
 
                 mtimes[filename] = mtime


### PR DESCRIPTION
The existing version relies on the `/proc` filesystem so it doesn't work on Mac. This adds a version that uses `pkill`.