### PR TITLE
Add url_bytes to Request

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -48,10 +48,11 @@ class Request(dict):
         'app', 'headers', 'version', 'method', '_cookies', 'transport',
         'body', 'parsed_json', 'parsed_args', 'parsed_form', 'parsed_files',
         '_ip', '_parsed_url', 'uri_template', 'stream', '_remote_addr',
-        '_socket', '_port', '__weakref__'
+        '_socket', '_port', '__weakref__', 'raw_url'
     )
 
     def __init__(self, url_bytes, headers, version, method, transport):
+        self.raw_url = url_bytes
         # TODO: Content-Encoding detection
         self._parsed_url = parse_url(url_bytes)
         self.app = None


### PR DESCRIPTION
For some application, we need to have access to the raw unparsed URL from the Request object.