### PR TITLE
Sanitize the URL before redirecting

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -361,7 +361,7 @@ def redirect(to, headers=None, status=302,
     headers = headers or {}
 
     # URL Quote the URL before redirecting
-    safe_to = quote_plus(to, safe=':/#?&=')
+    safe_to = quote_plus(to, safe=":/#?&=@[]!$&'()*+,;")
 
     # According to RFC 7231, a relative URI is now permitted.
     headers['Location'] = safe_to

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -1,5 +1,6 @@
 from mimetypes import guess_type
 from os import path
+from urllib.parse import quote_plus
 
 try:
     from ujson import dumps as json_dumps
@@ -358,6 +359,9 @@ def redirect(to, headers=None, status=302,
     :returns: the redirecting Response
     """
     headers = headers or {}
+    
+    # URL Quote the URL before redirecting
+    safe_to = quote_plus(to, safe=':/#')
 
     # According to RFC 7231, a relative URI is now permitted.
     headers['Location'] = to

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -359,7 +359,7 @@ def redirect(to, headers=None, status=302,
     :returns: the redirecting Response
     """
     headers = headers or {}
-    
+
     # URL Quote the URL before redirecting
     safe_to = quote_plus(to, safe=':/#?&=')
 

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -361,7 +361,7 @@ def redirect(to, headers=None, status=302,
     headers = headers or {}
     
     # URL Quote the URL before redirecting
-    safe_to = quote_plus(to, safe=':/#')
+    safe_to = quote_plus(to, safe=':/#?&=')
 
     # According to RFC 7231, a relative URI is now permitted.
     headers['Location'] = safe_to

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -364,7 +364,7 @@ def redirect(to, headers=None, status=302,
     safe_to = quote_plus(to, safe=':/#')
 
     # According to RFC 7231, a relative URI is now permitted.
-    headers['Location'] = to
+    headers['Location'] = safe_to
 
     return HTTPResponse(
         status=status,

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -107,7 +107,5 @@ def test_redirect_with_header_injection(redirect_app):
         allow_redirects=False)
 
     assert response.status == 302
-    assert response.headers["Location"] == "/unsafe%0Atest-header:+"\
-                                           "test-value%0A%0Atest-body"
     assert "test-header" not in response.headers
     assert not response.text.startswith('test-body')

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -32,6 +32,10 @@ def redirect_app():
     def handler(request):
         return text('OK')
 
+    @app.route('/redirect_with_header_injection')
+    async def redirect_with_header_injection(request):
+        return redirect("/unsafe\ntest-header: test-value\n\ntest-body")
+
     return app
 
 
@@ -92,3 +96,18 @@ def test_chained_redirect(redirect_app):
         assert response.url.endswith('/3')
     except AttributeError:
         assert response.url.path.endswith('/3')
+
+
+def test_redirect_with_header_injection(redirect_app):
+    """
+    Test redirection to a URL with header and body injections.
+    """
+    request, response = redirect_app.test_client.get(
+        "/redirect_with_header_injection",
+        allow_redirects=False)
+
+    assert response.status == 302
+    assert response.headers["Location"] == "/unsafe%0Atest-header:+"\
+                                           "test-value%0A%0Atest-body"
+    assert "test-header" not in response.headers
+    assert not response.text.startswith('test-body')


### PR DESCRIPTION
One of our users over at @elixire found a vulnerability that allows users to inject stuff into the redirected URL, and this is due to the way Sanic handles redirects.

For example, trying to redirect to `http://example.com\ntest-header: test-value\n\ntest-body` results in this:

![](https://duckymomo.club/i/446j.png)

---

The fix involves sanitizing the URL through the use of [URL quoting, provided by urllib](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus). This escapes the unsafe characters and prevents the malicious injections to response headers (which may lead to various security issues, see below) or the response body.

Various characters are marked as safe as URL quoting them leads to issues with certain types of URLs. Said characters were chosen from [RFC3986](https://tools.ietf.org/html/rfc3986.html)'s list of reserved characters (see `2.2.  Reserved Characters` on Page 12 and 13). Urllib already marks unreserved characters as safe by default.

---

I didn't measure the performance implications of this change (my attempts at testing it were quite hacky and gave anywhere from -5ms to 5ms so... they're unreliable), but it shouldn't cause any notable difference, especially considering some possible ways that this can be exploited (for example with use of a malicious HPKP header to prevent users from accessing the site in the future).

If there's any changes you want me to make (different library, different safe characters, use of `quote` instead of `quote_plus`, adding a flag to disable sanitizing etc), please do let me know.

I can understand it if you decide that the small performance hit from this isn't worth the risks, but in that case I'd recommend adding a note on the documents (preferably around [here](http://sanic.readthedocs.io/en/latest/sanic/response.html#redirect)) noting that sanitizing the URL is recommended as various vulnerabilities are present in the redirect code.

---

A simpler fix to the vulnerability described above would be to strip newlines or replace them with percent sign alternatives, and if you want I can turn this PR into that.