### PR TITLE
Gracefully handle when the request_handler_task is cancelled.

### DIFF
--- a/tests/test_response_timeout.py
+++ b/tests/test_response_timeout.py
@@ -7,6 +7,7 @@ from sanic.config import Config
 Config.RESPONSE_TIMEOUT = 1
 response_timeout_app = Sanic('test_response_timeout')
 response_timeout_default_app = Sanic('test_response_timeout_default')
+response_handler_cancelled_app = Sanic('test_response_handler_cancelled')
 
 
 @response_timeout_app.route('/1')
@@ -36,3 +37,29 @@ def test_default_server_error_response_timeout():
     request, response = response_timeout_default_app.test_client.get('/1')
     assert response.status == 503
     assert response.text == 'Error: Response Timeout'
+
+
+response_handler_cancelled_app.flag = False
+
+
+@response_handler_cancelled_app.exception(asyncio.CancelledError)
+def handler_cancelled(request, exception):
+    # If we get a CancelledError, it means sanic has already sent a response,
+    # we should not ever have to handle a CancelledError.
+    response_handler_cancelled_app.flag = True
+    return text("App received CancelledError!", 500)
+    # The client will never receive this response, because the socket
+    # is already closed when we get a CancelledError.
+
+
+@response_handler_cancelled_app.route('/1')
+async def handler_3(request):
+    await asyncio.sleep(2)
+    return text('OK')
+
+
+def test_response_handler_cancelled():
+    request, response = response_handler_cancelled_app.test_client.get('/1')
+    assert response.status == 503
+    assert response.text == 'Error: Response Timeout'
+    assert response_handler_cancelled_app.flag is False


### PR DESCRIPTION
This PR contains modifications to the `handle_request` function to detect and gracefully handle the case that the request_handler Task is canceled by the sanic server while it is handling the request. One common occurrence of this is when the server encounters a ResponseTimeout error, it cancels the response_handler_task.

In this change, the CancelledError exception handler purposely sets `response` to `None` to drop references to the handler coroutine, in an attempt to preemptively release resources.

This commit also fixes a possible reference-before-assignment of the `response` variable in the `handle_request` function.

Finally, another byproduct of this change is that ResponseMiddleware will no longer run if the `response` is `None`.