### PR TITLE
disabled auto_reload by default in windows

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -671,8 +671,8 @@ class Sanic:
         """
         # Default auto_reload to false
         auto_reload = False
-        # If debug is set, default it to true
-        if debug:
+        # If debug is set, default it to true (unless on windows)
+        if debug and os.name == 'posix':
             auto_reload = True
         # Allow for overriding either of the defaults
         auto_reload = kwargs.get("auto_reload", auto_reload)


### PR DESCRIPTION
this half undoes the work in #1159, it doesn't really make sense to enable auto_reload by default (as a debug feature) on a windows if the feature doesn't work (raises NotImplementedError). 