### PR TITLE
Fix broken tests when aiohttp >= 3.3.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 aiofiles
-aiohttp>=2.3.0
+aiohttp>=2.3.0,<=3.2.1
 chardet<=2.3.0
 beautifulsoup4
 coverage

--- a/tests/test_keep_alive_timeout.py
+++ b/tests/test_keep_alive_timeout.py
@@ -9,14 +9,39 @@ import aiohttp
 from aiohttp import TCPConnector
 from sanic.testing import SanicTestClient, HOST, PORT
 
+try:
+    try:
+        import packaging # direct use
+    except ImportError:
+        # setuptools v39.0 and above.
+        try:
+            from setuptools.extern import packaging
+        except ImportError:
+            # Before setuptools v39.0
+            from pkg_resources.extern import packaging
+    version = packaging.version
+except ImportError:
+    raise RuntimeError("The 'packaging' library is missing.")
+
+aiohttp_version = version.parse(aiohttp.__version__)
 
 class ReuseableTCPConnector(TCPConnector):
     def __init__(self, *args, **kwargs):
         super(ReuseableTCPConnector, self).__init__(*args, **kwargs)
         self.old_proto = None
 
-    if aiohttp.__version__ >= '3.0':
-
+    if aiohttp_version >= version.parse('3.3.0'):
+        async def connect(self, req, traces, timeout):
+            new_conn = await super(ReuseableTCPConnector, self)\
+                                    .connect(req, traces, timeout)
+            if self.old_proto is not None:
+                if self.old_proto != new_conn._protocol:
+                    raise RuntimeError(
+                        "We got a new connection, wanted the same one!")
+            print(new_conn.__dict__)
+            self.old_proto = new_conn._protocol
+            return new_conn
+    elif aiohttp_version >= version.parse('3.0.0'):
         async def connect(self, req, traces=None):
             new_conn = await super(ReuseableTCPConnector, self)\
                                     .connect(req, traces=traces)
@@ -28,7 +53,6 @@ class ReuseableTCPConnector(TCPConnector):
             self.old_proto = new_conn._protocol
             return new_conn
     else:
-
         async def connect(self, req):
             new_conn = await super(ReuseableTCPConnector, self)\
                                     .connect(req)


### PR DESCRIPTION
The sanic tox.ini file specifies `aiohttp>=2.3.0,<=3.2.1` however the `requirements-dev.txt` specifies `aiohttp>=2.3.0`.
Which means that when a contributor checks out the code and installs the dev requirments, he will get a newer aiohttp (v3.3.2 currently).

This is a problem because in the tox environment using aiohttp <= 3.2.1, all tests are passing. However on a local dev machine using aiohttp >= 3.3.0 some tests break.

This PR fixes this in two ways.
Firstly, it fixes the requirements-dev.txt file by specifying a max-version for aiohttp (same as in tox.ini), and also I have fixed the failing tests so that they will actually work with aiohttp >= 3.3.0.

This PR also uses a better version comparison method than the old way of checking aiohttp which was simply doing a string comparison. This new method uses the `packaging.version` tools (should always be shipped with as part of setuptools) to do a proper version comparison. 