### PR TITLE
Fix auto_reload in Linux

### DIFF
--- a/sanic/reloader_helpers.py
+++ b/sanic/reloader_helpers.py
@@ -83,6 +83,7 @@ def kill_process_children_unix(pid):
         except ProcessLookupError:
             continue
 
+
 def kill_process_children_osx(pid):
     """Find and kill child processes of a process.
 


### PR DESCRIPTION
Fix two problems with the auto reloader in Linux.
1) Change 'posix' to 'linux' in sys.plaform check, because 'posix' is an invalid value and 'linux' is the correct value to use here.
2) In kill_process_children, don't just kill the 2nd level procs, also kill the 1st level procs.

Also in kill_process_children, catch and ignore errors in the case that the child proc is already killed.
Fixes https://github.com/channelcat/sanic/issues/1285