### PR TITLE
Use secrets for generating unique ping payloads

### DIFF
--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -1,6 +1,5 @@
 import asyncio
-import random
-import struct
+import secrets
 
 from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 from typing import (
@@ -764,7 +763,7 @@ class WebsocketImplProtocol:
 
             # Generate a unique random payload otherwise.
             while data is None or data in self.pings:
-                data = struct.pack("!I", random.getrandbits(32))
+                data = secrets.token_bytes(4)
 
             self.pings[data] = self.io_proto.loop.create_future()
 


### PR DESCRIPTION
Replaced random payload generation with secrets module for better security. [B311:blacklist] was failing in security tests.