### PR TITLE
Fix static file serving for directories with CJK characters

### DIFF
--- a/sanic/handlers/directory.py
+++ b/sanic/handlers/directory.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 from pathlib import Path
 from stat import S_ISDIR
 from typing import cast
+from urllib.parse import unquote
 
 from sanic.exceptions import NotFound
 from sanic.pages.directory_page import DirectoryPage, FileInfo
@@ -54,7 +55,7 @@ class DirectoryHandler:
         Returns:
             Response: The response object.
         """  # noqa: E501
-        current = path.strip("/")[len(self.base) :].strip("/")  # noqa: E203
+        current = unquote(path).strip("/")[len(self.base) :].strip("/")  # noqa: E203
         for file_name in self.index:
             index_file = self.directory / current / file_name
             if index_file.is_file():


### PR DESCRIPTION
Fixes #3008

- Fix 404 error when serving index files from directories with CJK (Chinese/Japanese/Korean) characters
- Add `unquote()` to decode URL-encoded paths in `DirectoryHandler.handle()`
