### PR TITLE
Remove setuptools as a runtime dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,6 @@ requirements = [
     "html5tagger>=1.2.1",
     "tracerite>=2.2.0",
     "typing-extensions>=4.4.0",
-    "setuptools>=70.1.0",
 ]
 
 tests_require = [


### PR DESCRIPTION
Remove `setuptools` from `install_requires` in `setup.py`. It is a build-time dependency only and should not be required at runtime.

The sanic package source code does not import `setuptools` or `pkg_resources` anywhere. It is already correctly declared as a build dependency in `pyproject.toml`.

Closes #3133