### PR TITLE
fix: Python 3.14 compatibility for deprecated asyncio APIs

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -416,7 +416,11 @@ class Sanic(
         try:
             return get_running_loop()
         except RuntimeError:  # no cov
-            return asyncio.get_event_loop_policy().get_event_loop()
+            import warnings
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                return asyncio.get_event_loop_policy().get_event_loop()
 
     # -------------------------------------------------------------------- #
     # Registration

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -8,7 +8,6 @@ from asyncio import (
     CancelledError,
     Protocol,
     all_tasks,
-    get_event_loop,
     get_running_loop,
     new_event_loop,
 )
@@ -577,7 +576,7 @@ class StartupMixin(metaclass=SanicMeta):
             ssl=ssl,
             sock=sock,
             unix=unix,
-            loop=get_event_loop(),
+            loop=get_running_loop(),
             protocol=protocol,
             backlog=backlog,
             run_async=return_asyncio_server,
@@ -622,7 +621,7 @@ class StartupMixin(metaclass=SanicMeta):
                 with suppress(AttributeError):
                     if task.get_name() == "RunServer":
                         task.cancel()
-            get_event_loop().stop()
+            get_running_loop().stop()
 
         if unregister:
             self.__class__.unregister_app(self)  # type: ignore

--- a/sanic/server/loop.py
+++ b/sanic/server/loop.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 
 from os import getenv
 
@@ -43,8 +44,12 @@ def try_use_uvloop() -> None:
             "false."
         )
 
-    if not isinstance(asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy):
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        if not isinstance(
+            asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy
+        ):
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
 def try_windows_loop():
@@ -58,7 +63,12 @@ def try_windows_loop():
         )
         return
 
-    if not isinstance(
-        asyncio.get_event_loop_policy(), asyncio.WindowsSelectorEventLoopPolicy
-    ):
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        if not isinstance(
+            asyncio.get_event_loop_policy(),
+            asyncio.WindowsSelectorEventLoopPolicy,
+        ):
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )

--- a/sanic/server/runners.py
+++ b/sanic/server/runners.py
@@ -170,10 +170,16 @@ def _setup_system_signals(
         if OS_IS_WINDOWS:
             ctrlc_workaround_for_windows(app)
         else:
+            import warnings
+
             for _signal in [SIGINT, SIGTERM]:
-                loop.add_signal_handler(
-                    _signal, partial(app.stop, terminate=False)
-                )
+                with warnings.catch_warnings():
+                    # Suppress uvloop's use of deprecated
+                    # asyncio.iscoroutinefunction on Python 3.14+
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    loop.add_signal_handler(
+                        _signal, partial(app.stop, terminate=False)
+                    )
 
 
 def _run_shutdown_coro(loop, coro):

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -130,7 +130,7 @@ class WebsocketImplProtocol:
             try:
                 loop = getattr(io_proto, "loop")
             except AttributeError:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
         if not loop:
             # This catch is for mypy type checker
             # to assert loop is not None here.


### PR DESCRIPTION
## Summary

Fixes #3132

Python 3.14 deprecated several asyncio APIs that Sanic uses, causing `DeprecationWarning`s (which become errors with `-W error`) and, in some code paths, `RuntimeError`s due to `asyncio.get_event_loop()` no longer creating an implicit event loop.

## Changes

### `sanic/server/loop.py`
- Wrap `asyncio.get_event_loop_policy()` and `asyncio.set_event_loop_policy()` calls in `warnings.catch_warnings()` to suppress the deprecation warnings (deprecated in 3.14, removal in 3.16). This also suppresses the cascading `asyncio.AbstractEventLoopPolicy` deprecation from uvloop.

### `sanic/mixins/startup.py`
- Replace `get_event_loop()` with `get_running_loop()` in `create_server()` (async method) and `stop()` — both run inside an event loop, so `get_running_loop()` is correct and doesn't trigger the Python 3.14 deprecation/error.

### `sanic/app.py`
- Suppress deprecation warning in the `loop` property fallback path that uses `get_event_loop_policy().get_event_loop()`.

### `sanic/server/runners.py`
- Suppress uvloop's internal use of deprecated `asyncio.iscoroutinefunction` in `loop.add_signal_handler()` calls.

### `sanic/server/websockets/impl.py`
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` — this code always runs within an active event loop.

## Testing
- All signal-related tests pass (`test_signals.py`, `test_signal_handlers.py`)
- Production mode (single and multi-worker) starts and serves requests without deprecation warnings on Python 3.14.2
- Verified with `python3 -W error::DeprecationWarning` — no sanic-originated deprecation warnings remain.