### PR TITLE
Use None check for request.id to preserve falsy IDs

### DIFF
--- a/sanic/request/types.py
+++ b/sanic/request/types.py
@@ -521,7 +521,7 @@ class Request(Generic[sanic_type, ctx_type]):
             uuid.UUID | str | int | None: A request ID passed from the
                 client, or generated from the backend.
         """
-        if not self._id:
+        if self._id is None:
             self._id = self.headers.getone(
                 self.app.config.REQUEST_ID_HEADER,
                 self.__class__.generate_id(self),  # type: ignore


### PR DESCRIPTION
The `request.id` property uses `if not self._id` to decide whether to generate/fetch the ID. This treats any falsy value (including `0`, `""`) as "not yet set," causing the ID to be regenerated on every property access.

A custom `generate_id()` returning `0` or an integer request ID header value of `"0"` (which gets cast to `int(0)`) would trigger re-generation every time `request.id` is read. Switching to `is None` preserves any explicitly-set falsy ID while still triggering lazy initialization when genuinely unset.
