### PR TITLE
fix: resolve Python 3.14 deprecation warnings for asyncio event loop policy

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -416,7 +416,7 @@ class Sanic(
         try:
             return get_running_loop()
         except RuntimeError:  # no cov
-            return asyncio.get_event_loop_policy().get_event_loop()
+            return asyncio.new_event_loop()
 
     # -------------------------------------------------------------------- #
     # Registration

--- a/sanic/server/loop.py
+++ b/sanic/server/loop.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 from os import getenv
 
@@ -43,8 +44,17 @@ def try_use_uvloop() -> None:
             "false."
         )
 
-    if not isinstance(asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy):
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    if sys.version_info >= (3, 12):
+        # Python 3.12+: use set_event_loop_factory (avoids deprecated policy API)
+        if hasattr(asyncio, "set_event_loop_factory"):
+            asyncio.set_event_loop_factory(uvloop.new_event_loop)
+        else:
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    else:
+        if not isinstance(
+            asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy
+        ):
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
 def try_windows_loop():
@@ -58,7 +68,21 @@ def try_windows_loop():
         )
         return
 
-    if not isinstance(
-        asyncio.get_event_loop_policy(), asyncio.WindowsSelectorEventLoopPolicy
-    ):
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    if sys.version_info >= (3, 12):
+        # Python 3.12+: use set_event_loop_factory (avoids deprecated policy API)
+        if hasattr(asyncio, "set_event_loop_factory"):
+            asyncio.set_event_loop_factory(
+                asyncio.WindowsSelectorEventLoop
+            )
+        else:
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )
+    else:
+        if not isinstance(
+            asyncio.get_event_loop_policy(),
+            asyncio.WindowsSelectorEventLoopPolicy,
+        ):
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )


### PR DESCRIPTION
## Summary

Fixes #3129

Replaces deprecated `asyncio.get_event_loop_policy()` and `asyncio.set_event_loop_policy()` calls with `sys.version_info` checks that use `asyncio.set_event_loop_factory()` on Python 3.12+ where available.

## Changes

### sanic/server/loop.py
- `try_use_uvloop()`: On Python 3.12+ with `set_event_loop_factory` available, use it instead of the deprecated policy API. Falls back to policy API for older Python versions.
- `try_windows_loop()`: Same pattern for Windows selector event loop.

### sanic/app.py
- `get_loop()`: Replace `asyncio.get_event_loop_policy().get_event_loop()` with `asyncio.new_event_loop()` to avoid deprecated policy API.

## Compatibility
- Python 3.10-3.11: Uses existing `asyncio.set_event_loop_policy()` API (not deprecated in these versions)
- Python 3.12-3.13: Uses policy API (not yet deprecated)
- Python 3.14+: Uses `asyncio.set_event_loop_factory()` (avoids deprecation warnings)

## Testing
The fix uses `hasattr(asyncio, 'set_event_loop_factory')` as a feature-detection fallback, so it's safe even if the attribute is unexpectedly unavailable.
