### PR TITLE
Fix TLS redirect doc example to use `startup()`

### DIFF
--- a/guide/content/en/guide/how-to/tls.md
+++ b/guide/content/en/guide/how-to/tls.md
@@ -158,9 +158,7 @@ async def stop(app, _):
 async def runner(app, app_server):
     app.state.is_running = True
     try:
-        app.signalize()
-        app.finalize()
-        app.state.is_started = True
+        await app_server.startup()
         await app_server.serve_forever()
     finally:
         app.state.is_running = False


### PR DESCRIPTION
Replace manual `app.signalize()`, `app.finalize()`, and `app.state.is_started = True` with `await app_server.startup()` in the HTTP-to-HTTPS redirect documentation

The `create_server` docstring explicitly recommends using `await app_server.startup()` for app initialization. The manual `signalize()`/`finalize()` approach skips steps that `_startup()` performs — extension setup, route duplicate checking, uvloop conflict detection, and touchup optimizations. While the manual approach works for trivial cases, `startup()` is the correct API and safer to recommend in docs where users may adapt the pattern for more complex apps.

Resolves #2832 (remaining work after #2864)