### PR TITLE
Bump pygments to 2.20.0

### DIFF
--- a/guide/requirements.txt
+++ b/guide/requirements.txt
@@ -2,7 +2,7 @@ sanic>=23.12
 sanic-ext>=23.12
 msgspec
 python-frontmatter
-pygments
+pygments==2.20.0
 docstring-parser
 libsass
 mistune


### PR DESCRIPTION
These packages have security fixes available:

- `pygments` 2.19.2 -> 2.20.0 (CVE-2026-4539)

Bumped each one to the minimum safe version.