### PR TITLE
Add Redis-backed distributed job engine (sanic/jobs)

### DIFF
--- a/sanic/jobs/__init__.py
+++ b/sanic/jobs/__init__.py
@@ -1,0 +1,20 @@
+from sanic.jobs.base import SanicJob
+from sanic.jobs.constants import JobState
+from sanic.jobs.exceptions import (
+    JobDeserializationError,
+    JobError,
+    JobPerformError,
+    JobSerializationError,
+    JobTimeoutError,
+)
+
+
+__all__ = (
+    "JobDeserializationError",
+    "JobError",
+    "JobPerformError",
+    "JobSerializationError",
+    "JobState",
+    "JobTimeoutError",
+    "SanicJob",
+)

--- a/sanic/jobs/base.py
+++ b/sanic/jobs/base.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+import uuid
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any
+
+from sanic.jobs.constants import QUEUE_KEY_TEMPLATE, STATS_KEY
+from sanic.jobs.serializer import serialize_job
+
+
+logger = logging.getLogger("sanic.jobs")
+
+
+class SanicJob(ABC):
+    """Base class for background jobs.
+
+    Subclass this and implement ``perform`` to define a job.
+
+    Class attributes:
+        queue: Target queue name. Default ``"default"``.
+        max_retries: Maximum retry attempts. Default ``3``.
+        retry_delay: Delay between retries in seconds.
+            Default ``5``.
+    """
+
+    __slots__ = ()
+
+    queue: str = "default"
+    max_retries: int = 3
+    retry_delay: int = 5
+
+    @abstractmethod
+    async def perform(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the job. Must be overridden."""
+        ...
+
+    @classmethod
+    async def perform_later(
+        cls,
+        redis_client: Any,
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        """Enqueue a job for background execution.
+
+        Args:
+            redis_client: A ``redis.asyncio.Redis`` instance.
+            *args: Positional arguments for ``perform()``.
+            **kwargs: Keyword arguments for ``perform()``.
+
+        Returns:
+            The job ID (UUID4 string).
+        """
+        job_id = str(uuid.uuid4())
+        class_path = f"{cls.__module__}.{cls.__qualname__}"
+        enqueued_at = datetime.now(tz=timezone.utc).isoformat()
+        data = serialize_job(
+            job_class_path=class_path,
+            args=args,
+            kwargs=kwargs,
+            job_id=job_id,
+            queue=cls.queue,
+            enqueued_at=enqueued_at,
+        )
+        queue_key = QUEUE_KEY_TEMPLATE.format(name=cls.queue)
+        pipe = redis_client.pipeline()
+        pipe.lpush(queue_key, data)
+        pipe.hincrby(STATS_KEY, "enqueued", 1)
+        await pipe.execute()
+        logger.debug("Enqueued job %s on queue %s", job_id, cls.queue)
+        return job_id

--- a/sanic/jobs/constants.py
+++ b/sanic/jobs/constants.py
@@ -1,0 +1,24 @@
+from enum import IntEnum, auto
+
+
+class JobState(IntEnum):
+    """Job lifecycle states."""
+
+    PENDING = auto()
+    RUNNING = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+    RETRYING = auto()
+
+
+KEY_PREFIX = "sanic_jobs"
+QUEUE_KEY_TEMPLATE = f"{KEY_PREFIX}:queues:{{name}}"
+WORKER_KEY_TEMPLATE = f"{KEY_PREFIX}:workers:{{worker_id}}"
+STATS_KEY = f"{KEY_PREFIX}:stats"
+ACTIVE_WORKERS_SET = f"{KEY_PREFIX}:active_workers"
+
+DEFAULT_HEARTBEAT_INTERVAL = 5
+DEFAULT_HEARTBEAT_TTL = 15
+DEFAULT_SHUTDOWN_TIMEOUT = 30
+DEFAULT_CONCURRENCY = 10
+DEFAULT_BRPOP_TIMEOUT = 1

--- a/sanic/jobs/consumer.py
+++ b/sanic/jobs/consumer.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import signal
+import uuid
+
+from datetime import datetime, timezone
+from importlib import import_module
+from typing import Any
+
+from sanic.jobs.constants import (
+    ACTIVE_WORKERS_SET,
+    DEFAULT_BRPOP_TIMEOUT,
+    DEFAULT_CONCURRENCY,
+    DEFAULT_HEARTBEAT_INTERVAL,
+    DEFAULT_HEARTBEAT_TTL,
+    DEFAULT_SHUTDOWN_TIMEOUT,
+    QUEUE_KEY_TEMPLATE,
+    STATS_KEY,
+    WORKER_KEY_TEMPLATE,
+)
+from sanic.jobs.heartbeat import run_heartbeat
+from sanic.jobs.serializer import deserialize_job
+
+
+logger = logging.getLogger("sanic.jobs")
+
+
+class JobConsumer:
+    """Standalone job consumer that pulls and executes
+    jobs from Redis queues.
+
+    Args:
+        redis_url: Redis connection URL.
+        queues: List of queue names to poll.
+        concurrency: Maximum concurrent jobs.
+        shutdown_timeout: Seconds to wait for active jobs
+            during graceful shutdown.
+        heartbeat_interval: Seconds between heartbeats.
+    """
+
+    __slots__ = (
+        "_active_tasks",
+        "_concurrency",
+        "_heartbeat_interval",
+        "_heartbeat_task",
+        "_poll_task",
+        "_queues",
+        "_redis",
+        "_redis_url",
+        "_semaphore",
+        "_shutdown_timeout",
+        "_shutting_down",
+        "_started_at",
+        "_worker_id",
+    )
+
+    def __init__(
+        self,
+        redis_url: str,
+        queues: list[str] | None = None,
+        concurrency: int = DEFAULT_CONCURRENCY,
+        shutdown_timeout: int = DEFAULT_SHUTDOWN_TIMEOUT,
+        heartbeat_interval: int = DEFAULT_HEARTBEAT_INTERVAL,
+    ) -> None:
+        self._redis_url = redis_url
+        self._queues = queues or ["default"]
+        self._concurrency = concurrency
+        self._shutdown_timeout = shutdown_timeout
+        self._heartbeat_interval = heartbeat_interval
+        self._worker_id = f"worker-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+        self._redis: Any = None
+        self._semaphore: asyncio.BoundedSemaphore | None = None
+        self._active_tasks: set[asyncio.Task[None]] = set()
+        self._shutting_down = False
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._poll_task: asyncio.Task[None] | None = None
+        self._started_at = ""
+
+    async def start(self) -> None:
+        """Connect to Redis and begin processing jobs."""
+        from redis.asyncio import from_url
+
+        self._redis = from_url(self._redis_url)
+        self._semaphore = asyncio.BoundedSemaphore(self._concurrency)
+        self._started_at = datetime.now(tz=timezone.utc).isoformat()
+        self._setup_signals()
+        self._heartbeat_task = asyncio.create_task(
+            run_heartbeat(
+                redis=self._redis,
+                worker_id=self._worker_id,
+                interval=self._heartbeat_interval,
+                ttl=DEFAULT_HEARTBEAT_TTL,
+                get_status=self._get_status,
+            )
+        )
+        logger.info(
+            "Worker %s started (concurrency=%d, queues=%s)",
+            self._worker_id,
+            self._concurrency,
+            ",".join(self._queues),
+        )
+        await self._poll_loop()
+
+    async def _poll_loop(self) -> None:
+        """Main loop: acquire semaphore, BRPOP, dispatch."""
+        queue_keys = [QUEUE_KEY_TEMPLATE.format(name=q) for q in self._queues]
+        assert self._semaphore is not None
+        while not self._shutting_down:
+            await self._semaphore.acquire()
+            if self._shutting_down:
+                self._semaphore.release()
+                break
+            try:
+                result = await self._redis.brpop(
+                    *queue_keys,
+                    timeout=DEFAULT_BRPOP_TIMEOUT,
+                )
+            except asyncio.CancelledError:
+                self._semaphore.release()
+                break
+            except Exception:
+                logger.exception("BRPOP error")
+                self._semaphore.release()
+                continue
+            if result is None:
+                self._semaphore.release()
+                continue
+            _queue_key, raw_data = result
+            task = asyncio.create_task(self._execute_job(raw_data))
+            self._active_tasks.add(task)
+            task.add_done_callback(self._task_done)
+
+    async def _execute_job(self, raw_data: bytes) -> None:
+        """Deserialize, import, instantiate, and run a job."""
+        payload: dict[str, Any] = {}
+        try:
+            payload = deserialize_job(raw_data)
+            class_path = payload["class"]
+            args = payload.get("args", [])
+            kwargs = payload.get("kwargs", {})
+            job_cls = self._import_job_class(class_path)
+            job = job_cls()
+            logger.debug(
+                "Executing job %s (%s)",
+                payload.get("id", "?"),
+                class_path,
+            )
+            await job.perform(*args, **kwargs)
+            await self._redis.hincrby(STATS_KEY, "completed", 1)
+            logger.debug(
+                "Job %s completed",
+                payload.get("id", "?"),
+            )
+        except Exception:
+            await self._redis.hincrby(STATS_KEY, "failed", 1)
+            logger.exception(
+                "Job %s failed",
+                payload.get("id", "?"),
+            )
+
+    def _task_done(self, task: asyncio.Task[None]) -> None:
+        """Callback: release semaphore, remove from set."""
+        self._active_tasks.discard(task)
+        if self._semaphore is not None:
+            self._semaphore.release()
+        exc = task.exception() if not task.cancelled() else None
+        if exc:
+            logger.error("Task exception: %s", exc, exc_info=exc)
+
+    async def shutdown(self) -> None:
+        """Gracefully stop accepting jobs and drain."""
+        if self._shutting_down:
+            logger.warning("Force shutdown requested")
+            for t in list(self._active_tasks):
+                t.cancel()
+            return
+        self._shutting_down = True
+        logger.info(
+            "Shutting down worker %s (%d active jobs, timeout=%ds)",
+            self._worker_id,
+            len(self._active_tasks),
+            self._shutdown_timeout,
+        )
+        if self._active_tasks:
+            done, pending = await asyncio.wait(
+                self._active_tasks,
+                timeout=self._shutdown_timeout,
+            )
+            for t in pending:
+                t.cancel()
+            if pending:
+                await asyncio.wait(pending, timeout=1.0)
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+        if self._redis is not None:
+            try:
+                key = WORKER_KEY_TEMPLATE.format(worker_id=self._worker_id)
+                pipe = self._redis.pipeline()
+                pipe.delete(key)
+                pipe.srem(ACTIVE_WORKERS_SET, self._worker_id)
+                await pipe.execute()
+            except Exception:
+                logger.exception("Error cleaning up Redis state")
+            await self._redis.aclose()
+        logger.info("Worker %s shut down", self._worker_id)
+
+    def _setup_signals(self) -> None:
+        """Register SIGINT/SIGTERM handlers."""
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(
+                sig,
+                lambda: asyncio.ensure_future(self.shutdown()),
+            )
+
+    def _get_status(self) -> dict[str, str]:
+        """Build current status dict for heartbeat."""
+        return {
+            "pid": str(os.getpid()),
+            "queues": ",".join(self._queues),
+            "concurrency": str(self._concurrency),
+            "active_jobs": str(len(self._active_tasks)),
+            "state": ("shutting_down" if self._shutting_down else "running"),
+            "started_at": self._started_at,
+        }
+
+    @staticmethod
+    def _import_job_class(class_path: str) -> type:
+        """Dynamically import a job class by path."""
+        module_path, class_name = class_path.rsplit(".", 1)
+        module = import_module(module_path)
+        return getattr(module, class_name)
+
+
+def main() -> None:
+    """CLI entry point for the job consumer."""
+    parser = argparse.ArgumentParser(
+        description="Sanic Job Worker Consumer",
+    )
+    parser.add_argument(
+        "--redis-url",
+        default="redis://localhost:6379/0",
+        help="Redis connection URL",
+    )
+    parser.add_argument(
+        "--queues",
+        default="default",
+        help="Comma-separated queue names",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=DEFAULT_CONCURRENCY,
+        help="Max concurrent jobs",
+    )
+    parser.add_argument(
+        "--shutdown-timeout",
+        type=int,
+        default=DEFAULT_SHUTDOWN_TIMEOUT,
+        help="Graceful shutdown timeout (seconds)",
+    )
+    parser.add_argument(
+        "--heartbeat-interval",
+        type=int,
+        default=DEFAULT_HEARTBEAT_INTERVAL,
+        help="Heartbeat interval (seconds)",
+    )
+    args = parser.parse_args()
+    queues = [q.strip() for q in args.queues.split(",")]
+    logging.basicConfig(
+        level=logging.INFO,
+        format=("%(asctime)s [%(levelname)s] %(name)s: %(message)s"),
+    )
+    consumer = JobConsumer(
+        redis_url=args.redis_url,
+        queues=queues,
+        concurrency=args.concurrency,
+        shutdown_timeout=args.shutdown_timeout,
+        heartbeat_interval=args.heartbeat_interval,
+    )
+    try:
+        asyncio.run(consumer.start())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/sanic/jobs/exceptions.py
+++ b/sanic/jobs/exceptions.py
@@ -1,0 +1,38 @@
+class JobError(Exception):
+    """Base exception for job engine errors."""
+
+    __slots__ = ("message",)
+
+    def __init__(self, message: str = "") -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class JobSerializationError(JobError):
+    """Raised when a job payload cannot be serialized."""
+
+    __slots__ = ()
+
+
+class JobDeserializationError(JobError):
+    """Raised when a job payload cannot be deserialized."""
+
+    __slots__ = ()
+
+
+class JobTimeoutError(JobError):
+    """Raised when a job exceeds its timeout."""
+
+    __slots__ = ()
+
+
+class JobPerformError(JobError):
+    """Raised when perform() raises an unhandled exception."""
+
+    __slots__ = ("original",)
+
+    def __init__(
+        self, message: str = "", original: BaseException | None = None
+    ) -> None:
+        self.original = original
+        super().__init__(message)

--- a/sanic/jobs/heartbeat.py
+++ b/sanic/jobs/heartbeat.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from sanic.jobs.constants import (
+    ACTIVE_WORKERS_SET,
+    WORKER_KEY_TEMPLATE,
+)
+
+
+logger = logging.getLogger("sanic.jobs")
+
+
+async def run_heartbeat(
+    redis: Any,
+    worker_id: str,
+    interval: int,
+    ttl: int,
+    get_status: Callable[[], dict[str, str]],
+) -> None:
+    """Write worker heartbeat to Redis periodically.
+
+    The worker hash key is set with a TTL so it
+    auto-expires if the worker crashes.
+
+    Args:
+        redis: ``redis.asyncio.Redis`` instance.
+        worker_id: Unique worker identifier.
+        interval: Seconds between heartbeats.
+        ttl: TTL for the worker key in seconds.
+        get_status: Returns current worker status dict.
+    """
+    key = WORKER_KEY_TEMPLATE.format(worker_id=worker_id)
+    try:
+        while True:
+            status = get_status()
+            status["last_heartbeat"] = datetime.now(
+                tz=timezone.utc
+            ).isoformat()
+            status["worker_id"] = worker_id
+            pipe = redis.pipeline()
+            pipe.delete(key)
+            pipe.hset(key, mapping=status)
+            pipe.expire(key, ttl)
+            pipe.sadd(ACTIVE_WORKERS_SET, worker_id)
+            await pipe.execute()
+            logger.debug(
+                "Heartbeat sent for worker %s",
+                worker_id,
+            )
+            await asyncio.sleep(interval)
+    except asyncio.CancelledError:
+        logger.debug(
+            "Heartbeat stopped for worker %s",
+            worker_id,
+        )

--- a/sanic/jobs/monitor.py
+++ b/sanic/jobs/monitor.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+
+from typing import Any
+
+from sanic.jobs.constants import (
+    ACTIVE_WORKERS_SET,
+    KEY_PREFIX,
+    STATS_KEY,
+    WORKER_KEY_TEMPLATE,
+)
+
+
+logger = logging.getLogger("sanic.jobs")
+
+
+async def fetch_status(redis_url: str) -> dict[str, Any]:
+    """Query Redis and compile telemetry data.
+
+    Args:
+        redis_url: Redis connection URL.
+
+    Returns:
+        Dict with ``workers``, ``queues``, and ``stats``.
+    """
+    from redis.asyncio import from_url
+
+    redis = from_url(redis_url)
+    try:
+        return await _gather_status(redis)
+    finally:
+        await redis.aclose()
+
+
+async def fetch_status_from_client(
+    redis: Any,
+) -> dict[str, Any]:
+    """Query Redis using an existing client.
+
+    Args:
+        redis: ``redis.asyncio.Redis`` instance.
+
+    Returns:
+        Dict with ``workers``, ``queues``, and ``stats``.
+    """
+    return await _gather_status(redis)
+
+
+async def _gather_status(
+    redis: Any,
+) -> dict[str, Any]:
+    """Internal: gather all telemetry from Redis."""
+    workers: dict[str, Any] = {}
+    member_ids = await redis.smembers(ACTIVE_WORKERS_SET)
+    stale_ids: list[bytes | str] = []
+
+    for wid_raw in member_ids:
+        wid = (
+            wid_raw.decode("utf-8") if isinstance(wid_raw, bytes) else wid_raw
+        )
+        key = WORKER_KEY_TEMPLATE.format(worker_id=wid)
+        data = await redis.hgetall(key)
+        if not data:
+            stale_ids.append(wid_raw)
+            continue
+        decoded: dict[str, str] = {}
+        for k, v in data.items():
+            dk = k.decode("utf-8") if isinstance(k, bytes) else k
+            dv = v.decode("utf-8") if isinstance(v, bytes) else v
+            decoded[dk] = dv
+        workers[wid] = {
+            "status": decoded.get("state", "unknown"),
+            "concurrency_limit": int(decoded.get("concurrency", "0")),
+            "active_threads": int(decoded.get("active_jobs", "0")),
+            "pid": decoded.get("pid", ""),
+            "queues": decoded.get("queues", ""),
+            "started_at": decoded.get("started_at", ""),
+            "last_heartbeat": decoded.get("last_heartbeat", ""),
+        }
+
+    if stale_ids:
+        await redis.srem(ACTIVE_WORKERS_SET, *stale_ids)
+
+    queues: dict[str, Any] = {}
+    queue_prefix = f"{KEY_PREFIX}:queues:"
+    cursor: int | bytes = 0
+    while True:
+        cursor, keys = await redis.scan(
+            cursor=cursor,
+            match=f"{queue_prefix}*",
+            count=100,
+        )
+        for key in keys:
+            qname_raw = key.decode("utf-8") if isinstance(key, bytes) else key
+            qname = qname_raw[len(queue_prefix) :]
+            depth = await redis.llen(key)
+            queues[qname] = {"enqueued_jobs": depth}
+        if cursor == 0 or cursor == b"0":
+            break
+
+    raw_stats = await redis.hgetall(STATS_KEY)
+    stats: dict[str, int] = {
+        "processed_total": 0,
+        "failed_total": 0,
+        "enqueued_total": 0,
+    }
+    if raw_stats:
+        for k, v in raw_stats.items():
+            dk = k.decode("utf-8") if isinstance(k, bytes) else k
+            dv = v.decode("utf-8") if isinstance(v, bytes) else str(v)
+            if dk == "completed":
+                stats["processed_total"] = int(dv)
+            elif dk == "failed":
+                stats["failed_total"] = int(dv)
+            elif dk == "enqueued":
+                stats["enqueued_total"] = int(dv)
+
+    return {
+        "workers": workers,
+        "queues": queues,
+        "stats": stats,
+    }
+
+
+def main() -> None:
+    """CLI entry point for the job monitor."""
+    parser = argparse.ArgumentParser(
+        description="Sanic Job Monitor",
+    )
+    parser.add_argument(
+        "--redis-url",
+        default="redis://localhost:6379/0",
+        help="Redis connection URL",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Output JSON telemetry",
+    )
+    args = parser.parse_args()
+    if args.status:
+        result = asyncio.run(fetch_status(args.redis_url))
+        print(json.dumps(result, indent=2))
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/sanic/jobs/serializer.py
+++ b/sanic/jobs/serializer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import Any
+
+from sanic.jobs.exceptions import (
+    JobDeserializationError,
+    JobSerializationError,
+)
+
+
+try:
+    from ujson import dumps as json_dumps
+    from ujson import loads as json_loads
+except ModuleNotFoundError:
+    from json import dumps, loads  # type: ignore[assignment]
+
+    json_dumps = partial(dumps, separators=(",", ":"))  # type: ignore
+    json_loads = loads  # type: ignore
+
+
+def serialize_job(
+    job_class_path: str,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    job_id: str,
+    queue: str,
+    enqueued_at: str,
+    retry_count: int = 0,
+) -> bytes:
+    """Serialize a job payload to JSON bytes.
+
+    Args:
+        job_class_path: Fully qualified class path.
+        args: Positional arguments for perform().
+        kwargs: Keyword arguments for perform().
+        job_id: Unique job identifier (UUID4).
+        queue: Target queue name.
+        enqueued_at: ISO timestamp of enqueue time.
+        retry_count: Current retry attempt number.
+
+    Returns:
+        UTF-8 encoded JSON bytes.
+    """
+    payload = {
+        "id": job_id,
+        "class": job_class_path,
+        "queue": queue,
+        "args": list(args),
+        "kwargs": kwargs,
+        "enqueued_at": enqueued_at,
+        "retry_count": retry_count,
+    }
+    try:
+        return json_dumps(payload).encode("utf-8")
+    except (TypeError, ValueError) as e:
+        raise JobSerializationError(f"Failed to serialize job: {e}") from e
+
+
+def deserialize_job(data: bytes) -> dict[str, Any]:
+    """Deserialize a job payload from JSON bytes.
+
+    Args:
+        data: UTF-8 encoded JSON bytes.
+
+    Returns:
+        Parsed job payload dict.
+    """
+    try:
+        return json_loads(data)
+    except (TypeError, ValueError) as e:
+        raise JobDeserializationError(f"Failed to deserialize job: {e}") from e

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,9 @@ tests_require = [
     "uvicorn",
     "slotscheck>=0.8.0,<1",
     types_ujson,
+    "fakeredis[lua]",
+    "redis>=5.0.0",
+    "pytest-asyncio",
 ]
 
 docs_require = [
@@ -188,6 +191,7 @@ extras_require = {
     "all": all_require,
     "ext": ["sanic-ext"],
     "http3": ["aioquic"],
+    "jobs": ["redis>=5.0.0"],
 }
 
 setup_kwargs["install_requires"] = requirements

--- a/tests/jobs/conftest.py
+++ b/tests/jobs/conftest.py
@@ -1,0 +1,69 @@
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+import fakeredis.aioredis
+
+from sanic.jobs.base import SanicJob
+
+
+@pytest_asyncio.fixture
+async def fake_redis():
+    r = fakeredis.aioredis.FakeRedis()
+    yield r
+    await r.aclose()
+
+
+class AddJob(SanicJob):
+    __slots__ = ()
+    queue = "test_queue"
+
+    async def perform(self, a, b):
+        return a + b
+
+
+class SlowJob(SanicJob):
+    __slots__ = ()
+    queue = "default"
+
+    async def perform(self, duration=0.5):
+        await asyncio.sleep(duration)
+
+
+class FailJob(SanicJob):
+    __slots__ = ()
+    queue = "default"
+
+    async def perform(self):
+        raise ValueError("deliberate failure")
+
+
+class TrackingJob(SanicJob):
+    __slots__ = ()
+    queue = "default"
+    results: list = []
+
+    async def perform(self, value):
+        TrackingJob.results.append(value)
+
+
+@pytest.fixture
+def add_job_class():
+    return AddJob
+
+
+@pytest.fixture
+def slow_job_class():
+    return SlowJob
+
+
+@pytest.fixture
+def fail_job_class():
+    return FailJob
+
+
+@pytest.fixture
+def tracking_job_class():
+    TrackingJob.results = []
+    return TrackingJob

--- a/tests/jobs/test_base.py
+++ b/tests/jobs/test_base.py
@@ -1,0 +1,92 @@
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from sanic.jobs.base import SanicJob
+from sanic.jobs.constants import QUEUE_KEY_TEMPLATE, STATS_KEY
+from sanic.jobs.serializer import deserialize_job
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_perform_later_enqueues_job(
+    fake_redis, add_job_class
+):
+    job_id = await add_job_class.perform_later(
+        fake_redis, 1, 2
+    )
+    key = QUEUE_KEY_TEMPLATE.format(name="test_queue")
+    length = await fake_redis.llen(key)
+    assert length == 1
+    assert uuid.UUID(job_id, version=4)
+
+
+async def test_perform_later_increments_enqueued_stat(
+    fake_redis, add_job_class
+):
+    await add_job_class.perform_later(fake_redis, 1, 2)
+    val = await fake_redis.hget(STATS_KEY, "enqueued")
+    assert int(val) == 1
+
+    await add_job_class.perform_later(fake_redis, 3, 4)
+    val = await fake_redis.hget(STATS_KEY, "enqueued")
+    assert int(val) == 2
+
+
+async def test_perform_later_serialization_format(
+    fake_redis, add_job_class
+):
+    job_id = await add_job_class.perform_later(
+        fake_redis, 10, b=20
+    )
+    key = QUEUE_KEY_TEMPLATE.format(name="test_queue")
+    raw = await fake_redis.rpop(key)
+    payload = deserialize_job(raw)
+
+    assert payload["id"] == job_id
+    assert payload["class"].endswith("AddJob")
+    assert payload["queue"] == "test_queue"
+    assert payload["args"] == [10]
+    assert payload["kwargs"] == {"b": 20}
+    assert "enqueued_at" in payload
+    assert payload["retry_count"] == 0
+
+
+async def test_perform_later_uses_class_queue(
+    fake_redis,
+):
+    class CriticalJob(SanicJob):
+        __slots__ = ()
+        queue = "critical"
+
+        async def perform(self):
+            pass
+
+    await CriticalJob.perform_later(fake_redis)
+    key = QUEUE_KEY_TEMPLATE.format(name="critical")
+    length = await fake_redis.llen(key)
+    assert length == 1
+
+
+async def test_perform_is_abstract():
+    with pytest.raises(TypeError):
+        SanicJob()
+
+
+async def test_multiple_enqueues_fifo_order(
+    fake_redis, add_job_class
+):
+    ids = []
+    for i in range(5):
+        jid = await add_job_class.perform_later(
+            fake_redis, i, 0
+        )
+        ids.append(jid)
+
+    key = QUEUE_KEY_TEMPLATE.format(name="test_queue")
+    for expected_id in ids:
+        raw = await fake_redis.rpop(key)
+        payload = deserialize_job(raw)
+        assert payload["id"] == expected_id

--- a/tests/jobs/test_consumer.py
+++ b/tests/jobs/test_consumer.py
@@ -1,0 +1,234 @@
+import asyncio
+import time
+
+import pytest
+import pytest_asyncio
+
+import fakeredis.aioredis
+
+from sanic.jobs.constants import (
+    QUEUE_KEY_TEMPLATE,
+    STATS_KEY,
+)
+from sanic.jobs.consumer import JobConsumer
+from sanic.jobs.serializer import serialize_job
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _enqueue_payload(
+    class_path, args=(), kwargs=None, queue="default"
+):
+    import uuid
+    from datetime import datetime, timezone
+
+    return serialize_job(
+        job_class_path=class_path,
+        args=args,
+        kwargs=kwargs or {},
+        job_id=str(uuid.uuid4()),
+        queue=queue,
+        enqueued_at=(
+            datetime.now(tz=timezone.utc).isoformat()
+        ),
+    )
+
+
+class _InlineConsumer(JobConsumer):
+    """Consumer that uses a provided fake redis."""
+
+    __slots__ = ("_provided_redis",)
+
+    def __init__(self, redis, **kwargs):
+        super().__init__(
+            redis_url="redis://fake", **kwargs
+        )
+        self._provided_redis = redis
+
+    async def start(self) -> None:
+        self._redis = self._provided_redis
+        self._semaphore = asyncio.BoundedSemaphore(
+            self._concurrency
+        )
+        from datetime import datetime, timezone
+
+        self._started_at = (
+            datetime.now(tz=timezone.utc).isoformat()
+        )
+        self._heartbeat_task = asyncio.create_task(
+            asyncio.sleep(999)
+        )
+        await self._poll_loop()
+
+
+async def test_concurrency_bounds_enforcement(
+    fake_redis,
+):
+    class_path = (
+        "tests.jobs.conftest.SlowJob"
+    )
+    key = QUEUE_KEY_TEMPLATE.format(name="default")
+    for _ in range(6):
+        data = _enqueue_payload(
+            class_path, kwargs={"duration": 0.5}
+        )
+        await fake_redis.lpush(key, data)
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=2,
+        queues=["default"],
+    )
+
+    start_time = time.monotonic()
+
+    async def stop_after():
+        await asyncio.sleep(2.5)
+        consumer._shutting_down = True
+
+    asyncio.create_task(stop_after())
+    await consumer.start()
+
+    elapsed = time.monotonic() - start_time
+    assert elapsed >= 1.4
+
+
+async def test_job_failure_increments_failed_counter(
+    fake_redis,
+):
+    class_path = "tests.jobs.conftest.FailJob"
+    key = QUEUE_KEY_TEMPLATE.format(name="default")
+    data = _enqueue_payload(class_path)
+    await fake_redis.lpush(key, data)
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["default"],
+    )
+
+    async def stop_after():
+        await asyncio.sleep(0.5)
+        consumer._shutting_down = True
+
+    asyncio.create_task(stop_after())
+    await consumer.start()
+
+    val = await fake_redis.hget(STATS_KEY, "failed")
+    assert val is not None
+    assert int(val) >= 1
+
+
+async def test_job_success_increments_completed_counter(
+    fake_redis,
+):
+    class_path = "tests.jobs.conftest.AddJob"
+    key = QUEUE_KEY_TEMPLATE.format(name="test_queue")
+    data = _enqueue_payload(
+        class_path,
+        args=(1, 2),
+        queue="test_queue",
+    )
+    await fake_redis.lpush(key, data)
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["test_queue"],
+    )
+
+    async def stop_after():
+        await asyncio.sleep(0.5)
+        consumer._shutting_down = True
+
+    asyncio.create_task(stop_after())
+    await consumer.start()
+
+    val = await fake_redis.hget(STATS_KEY, "completed")
+    assert val is not None
+    assert int(val) >= 1
+
+
+async def test_semaphore_released_on_failure(fake_redis):
+    fail_path = "tests.jobs.conftest.FailJob"
+    add_path = "tests.jobs.conftest.AddJob"
+    default_key = QUEUE_KEY_TEMPLATE.format(
+        name="default"
+    )
+    await fake_redis.lpush(
+        default_key,
+        _enqueue_payload(add_path, args=(1, 2)),
+    )
+    await fake_redis.lpush(
+        default_key,
+        _enqueue_payload(fail_path),
+    )
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["default"],
+    )
+
+    async def stop_after():
+        await asyncio.sleep(2.0)
+        consumer._shutting_down = True
+
+    asyncio.create_task(stop_after())
+    await consumer.start()
+
+    failed = await fake_redis.hget(STATS_KEY, "failed")
+    completed = await fake_redis.hget(
+        STATS_KEY, "completed"
+    )
+    assert int(failed or 0) >= 1
+    assert int(completed or 0) >= 1
+
+
+async def test_import_job_class_success():
+    cls = JobConsumer._import_job_class(
+        "tests.jobs.conftest.AddJob"
+    )
+    from tests.jobs.conftest import AddJob
+
+    assert cls is AddJob
+
+
+async def test_import_job_class_failure():
+    with pytest.raises(
+        (ImportError, AttributeError, ModuleNotFoundError)
+    ):
+        JobConsumer._import_job_class(
+            "nonexistent.module.FakeClass"
+        )
+
+
+async def test_fifo_order(fake_redis):
+    class_path = "tests.jobs.conftest.TrackingJob"
+    key = QUEUE_KEY_TEMPLATE.format(name="default")
+
+    from tests.jobs.conftest import TrackingJob
+
+    TrackingJob.results = []
+
+    for i in range(3):
+        data = _enqueue_payload(
+            class_path, args=(i,)
+        )
+        await fake_redis.lpush(key, data)
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["default"],
+    )
+
+    async def stop_after():
+        await asyncio.sleep(1.0)
+        consumer._shutting_down = True
+
+    asyncio.create_task(stop_after())
+    await consumer.start()
+
+    assert TrackingJob.results == [0, 1, 2]

--- a/tests/jobs/test_heartbeat.py
+++ b/tests/jobs/test_heartbeat.py
@@ -1,0 +1,144 @@
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from sanic.jobs.constants import (
+    ACTIVE_WORKERS_SET,
+    WORKER_KEY_TEMPLATE,
+)
+from sanic.jobs.heartbeat import run_heartbeat
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_status():
+    return {
+        "pid": "12345",
+        "queues": "default",
+        "concurrency": "5",
+        "active_jobs": "2",
+        "state": "running",
+        "started_at": "2026-01-01T00:00:00",
+    }
+
+
+async def test_heartbeat_writes_worker_key(fake_redis):
+    worker_id = "test-heartbeat-1"
+    task = asyncio.create_task(
+        run_heartbeat(
+            redis=fake_redis,
+            worker_id=worker_id,
+            interval=60,
+            ttl=120,
+            get_status=_make_status,
+        )
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    key = WORKER_KEY_TEMPLATE.format(
+        worker_id=worker_id
+    )
+    data = await fake_redis.hgetall(key)
+    assert data
+    decoded = {
+        (
+            k.decode("utf-8")
+            if isinstance(k, bytes)
+            else k
+        ): (
+            v.decode("utf-8")
+            if isinstance(v, bytes)
+            else v
+        )
+        for k, v in data.items()
+    }
+    assert decoded["pid"] == "12345"
+    assert decoded["state"] == "running"
+    assert decoded["worker_id"] == worker_id
+    assert "last_heartbeat" in decoded
+
+
+async def test_heartbeat_sets_ttl(fake_redis):
+    worker_id = "test-heartbeat-ttl"
+    task = asyncio.create_task(
+        run_heartbeat(
+            redis=fake_redis,
+            worker_id=worker_id,
+            interval=60,
+            ttl=120,
+            get_status=_make_status,
+        )
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    key = WORKER_KEY_TEMPLATE.format(
+        worker_id=worker_id
+    )
+    ttl = await fake_redis.ttl(key)
+    assert ttl > 0
+    assert ttl <= 120
+
+
+async def test_heartbeat_adds_to_active_workers(
+    fake_redis,
+):
+    worker_id = "test-heartbeat-active"
+    task = asyncio.create_task(
+        run_heartbeat(
+            redis=fake_redis,
+            worker_id=worker_id,
+            interval=60,
+            ttl=120,
+            get_status=_make_status,
+        )
+    )
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    is_member = await fake_redis.sismember(
+        ACTIVE_WORKERS_SET, worker_id
+    )
+    assert is_member
+
+
+async def test_heartbeat_updates_on_interval(fake_redis):
+    call_count = {"n": 0}
+
+    def counting_status():
+        call_count["n"] += 1
+        return _make_status()
+
+    worker_id = "test-heartbeat-interval"
+    task = asyncio.create_task(
+        run_heartbeat(
+            redis=fake_redis,
+            worker_id=worker_id,
+            interval=0.05,
+            ttl=120,
+            get_status=counting_status,
+        )
+    )
+    await asyncio.sleep(0.18)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert call_count["n"] >= 2

--- a/tests/jobs/test_monitor.py
+++ b/tests/jobs/test_monitor.py
@@ -1,0 +1,136 @@
+import pytest
+import pytest_asyncio
+
+from sanic.jobs.constants import (
+    ACTIVE_WORKERS_SET,
+    QUEUE_KEY_TEMPLATE,
+    STATS_KEY,
+    WORKER_KEY_TEMPLATE,
+)
+from sanic.jobs.monitor import fetch_status_from_client
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup_worker(redis, worker_id, data):
+    key = WORKER_KEY_TEMPLATE.format(
+        worker_id=worker_id
+    )
+    await redis.hset(key, mapping=data)
+    await redis.expire(key, 120)
+    await redis.sadd(ACTIVE_WORKERS_SET, worker_id)
+
+
+async def test_fetch_status_json_schema(fake_redis):
+    await _setup_worker(
+        fake_redis,
+        "worker-alpha",
+        {
+            "pid": "1234",
+            "queues": "default,heavy",
+            "concurrency": "10",
+            "active_jobs": "3",
+            "state": "running",
+            "started_at": "2026-01-01T00:00:00",
+            "last_heartbeat": "2026-01-01T00:01:00",
+            "worker_id": "worker-alpha",
+        },
+    )
+
+    queue_key = QUEUE_KEY_TEMPLATE.format(
+        name="default"
+    )
+    for _ in range(42):
+        await fake_redis.lpush(queue_key, b"job")
+
+    heavy_key = QUEUE_KEY_TEMPLATE.format(name="heavy")
+    await fake_redis.delete(heavy_key)
+
+    await fake_redis.hset(STATS_KEY, "completed", "1540")
+    await fake_redis.hset(STATS_KEY, "failed", "12")
+    await fake_redis.hset(STATS_KEY, "enqueued", "1600")
+
+    result = await fetch_status_from_client(fake_redis)
+
+    assert "workers" in result
+    assert "queues" in result
+    assert "stats" in result
+
+    w = result["workers"]["worker-alpha"]
+    assert w["status"] == "running"
+    assert w["concurrency_limit"] == 10
+    assert w["active_threads"] == 3
+    assert w["pid"] == "1234"
+
+    assert result["queues"]["default"]["enqueued_jobs"] == 42
+
+    assert result["stats"]["processed_total"] == 1540
+    assert result["stats"]["failed_total"] == 12
+    assert result["stats"]["enqueued_total"] == 1600
+
+
+async def test_fetch_status_empty_state(fake_redis):
+    result = await fetch_status_from_client(fake_redis)
+
+    assert result["workers"] == {}
+    assert result["queues"] == {}
+    assert result["stats"]["processed_total"] == 0
+    assert result["stats"]["failed_total"] == 0
+    assert result["stats"]["enqueued_total"] == 0
+
+
+async def test_fetch_status_prunes_expired_workers(
+    fake_redis,
+):
+    await fake_redis.sadd(
+        ACTIVE_WORKERS_SET, "stale-worker"
+    )
+
+    result = await fetch_status_from_client(fake_redis)
+
+    assert "stale-worker" not in result["workers"]
+    is_member = await fake_redis.sismember(
+        ACTIVE_WORKERS_SET, "stale-worker"
+    )
+    assert not is_member
+
+
+async def test_fetch_status_multiple_workers(fake_redis):
+    for i in range(3):
+        wid = f"worker-{i}"
+        await _setup_worker(
+            fake_redis,
+            wid,
+            {
+                "pid": str(1000 + i),
+                "queues": "default",
+                "concurrency": "5",
+                "active_jobs": str(i),
+                "state": "running",
+                "started_at": "2026-01-01T00:00:00",
+                "last_heartbeat": "2026-01-01T00:01:00",
+                "worker_id": wid,
+            },
+        )
+
+    result = await fetch_status_from_client(fake_redis)
+    assert len(result["workers"]) == 3
+    for i in range(3):
+        w = result["workers"][f"worker-{i}"]
+        assert w["active_threads"] == i
+
+
+async def test_fetch_status_multiple_queues(fake_redis):
+    for name, count in [
+        ("alpha", 10),
+        ("beta", 20),
+        ("gamma", 0),
+    ]:
+        key = QUEUE_KEY_TEMPLATE.format(name=name)
+        for _ in range(count):
+            await fake_redis.lpush(key, b"job")
+
+    result = await fetch_status_from_client(fake_redis)
+    assert result["queues"]["alpha"]["enqueued_jobs"] == 10
+    assert result["queues"]["beta"]["enqueued_jobs"] == 20

--- a/tests/jobs/test_shutdown.py
+++ b/tests/jobs/test_shutdown.py
@@ -1,0 +1,174 @@
+import asyncio
+import time
+
+import pytest
+import pytest_asyncio
+
+from sanic.jobs.constants import (
+    QUEUE_KEY_TEMPLATE,
+    STATS_KEY,
+    ACTIVE_WORKERS_SET,
+    WORKER_KEY_TEMPLATE,
+)
+from sanic.jobs.consumer import JobConsumer
+from sanic.jobs.serializer import serialize_job
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _enqueue_payload(
+    class_path, args=(), kwargs=None, queue="default"
+):
+    import uuid
+    from datetime import datetime, timezone
+
+    return serialize_job(
+        job_class_path=class_path,
+        args=args,
+        kwargs=kwargs or {},
+        job_id=str(uuid.uuid4()),
+        queue=queue,
+        enqueued_at=(
+            datetime.now(tz=timezone.utc).isoformat()
+        ),
+    )
+
+
+class _InlineConsumer(JobConsumer):
+    """Consumer that uses a provided fake redis."""
+
+    __slots__ = ("_provided_redis",)
+
+    def __init__(self, redis, **kwargs):
+        super().__init__(
+            redis_url="redis://fake", **kwargs
+        )
+        self._provided_redis = redis
+
+    async def start(self) -> None:
+        self._redis = self._provided_redis
+        self._semaphore = asyncio.BoundedSemaphore(
+            self._concurrency
+        )
+        from datetime import datetime, timezone
+
+        self._started_at = (
+            datetime.now(tz=timezone.utc).isoformat()
+        )
+        self._heartbeat_task = asyncio.create_task(
+            asyncio.sleep(999)
+        )
+        await self._poll_loop()
+
+
+async def test_shutdown_waits_for_active_tasks(
+    fake_redis,
+):
+    class_path = "tests.jobs.conftest.SlowJob"
+    key = QUEUE_KEY_TEMPLATE.format(name="default")
+    data = _enqueue_payload(
+        class_path, kwargs={"duration": 0.3}
+    )
+    await fake_redis.lpush(key, data)
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["default"],
+        shutdown_timeout=5,
+    )
+
+    async def trigger_shutdown():
+        await asyncio.sleep(0.1)
+        await consumer.shutdown()
+
+    poll_task = asyncio.create_task(consumer.start())
+    asyncio.create_task(trigger_shutdown())
+    await poll_task
+
+    val = await fake_redis.hget(STATS_KEY, "completed")
+    assert val is not None
+    assert int(val) >= 1
+
+
+async def test_shutdown_cancels_after_timeout(
+    fake_redis,
+):
+    class_path = "tests.jobs.conftest.SlowJob"
+    key = QUEUE_KEY_TEMPLATE.format(name="default")
+    data = _enqueue_payload(
+        class_path, kwargs={"duration": 10.0}
+    )
+    await fake_redis.lpush(key, data)
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["default"],
+        shutdown_timeout=0,
+    )
+
+    start = time.monotonic()
+
+    async def trigger_shutdown():
+        await asyncio.sleep(0.2)
+        await consumer.shutdown()
+
+    poll_task = asyncio.create_task(consumer.start())
+    asyncio.create_task(trigger_shutdown())
+    await poll_task
+
+    elapsed = time.monotonic() - start
+    assert elapsed < 3.0
+
+
+async def test_shutdown_stops_accepting_new_jobs(
+    fake_redis,
+):
+    class_path = "tests.jobs.conftest.SlowJob"
+    key = QUEUE_KEY_TEMPLATE.format(name="default")
+    for _ in range(5):
+        data = _enqueue_payload(
+            class_path, kwargs={"duration": 0.3}
+        )
+        await fake_redis.lpush(key, data)
+
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["default"],
+        shutdown_timeout=2,
+    )
+
+    async def trigger_shutdown():
+        await asyncio.sleep(0.2)
+        await consumer.shutdown()
+
+    poll_task = asyncio.create_task(consumer.start())
+    asyncio.create_task(trigger_shutdown())
+    await poll_task
+
+    completed_raw = await fake_redis.hget(
+        STATS_KEY, "completed"
+    )
+    completed = int(completed_raw or 0)
+    assert completed < 5
+
+
+async def test_connection_pool_cleanup(fake_redis):
+    consumer = _InlineConsumer(
+        redis=fake_redis,
+        concurrency=1,
+        queues=["default"],
+    )
+
+    consumer._redis = fake_redis
+    consumer._semaphore = asyncio.BoundedSemaphore(1)
+    consumer._heartbeat_task = asyncio.create_task(
+        asyncio.sleep(999)
+    )
+    consumer._started_at = "2026-01-01T00:00:00"
+
+    await consumer.shutdown()
+    assert consumer._shutting_down is True


### PR DESCRIPTION
Implement a standalone, Sidekiq-inspired background job processing framework with decoupled producer/consumer architecture, bounded concurrency via asyncio.BoundedSemaphore, TTL-based worker heartbeats, atomic BRPOP delivery, graceful SIGINT/SIGTERM shutdown, and a CLI monitoring tool that outputs structured JSON telemetry.