### PR TITLE
Fix route handler callable typing

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1299,7 +1299,7 @@ class Sanic(
         # allocation before assignment below.
         response: (
             BaseHTTPResponse
-            | Coroutine[Any, Any, BaseHTTPResponse | None]
+            | Awaitable[BaseHTTPResponse | None]
             | ResponseStream
             | None
         ) = None

--- a/sanic/models/handler_types.py
+++ b/sanic/models/handler_types.py
@@ -1,5 +1,5 @@
 from asyncio.events import AbstractEventLoop
-from collections.abc import Coroutine
+from collections.abc import Awaitable, Coroutine
 from typing import Any, Callable, TypeVar
 
 import sanic
@@ -26,5 +26,5 @@ ListenerType = (
     Callable[[Sanic], Coroutine[Any, Any, None] | None]
     | Callable[[Sanic, AbstractEventLoop], Coroutine[Any, Any, None] | None]
 )
-RouteHandler = Callable[..., Coroutine[Any, Any, HTTPResponse | None]]
+RouteHandler = Callable[..., Awaitable[HTTPResponse | None]]
 SignalHandler = Callable[..., Coroutine[Any, Any, None]]

--- a/tests/typing/samples/route_handler_registration.py
+++ b/tests/typing/samples/route_handler_registration.py
@@ -1,0 +1,15 @@
+from types import SimpleNamespace
+
+from sanic import Request, Sanic
+from sanic.config import Config
+from sanic.response import HTTPResponse, empty
+
+
+class RouteContainer:
+    def setup_routes(self, app: Sanic[Config, SimpleNamespace]) -> None:
+        app.get("/api")(self.api)
+
+    async def api(
+        self, request: Request[Sanic[Config, SimpleNamespace], SimpleNamespace]
+    ) -> HTTPResponse:
+        return empty(200)

--- a/tests/typing/test_typing.py
+++ b/tests/typing/test_typing.py
@@ -3,6 +3,7 @@
 import subprocess
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -15,13 +16,19 @@ def run_check(path_location: str) -> str:
 
     mypy_path = "mypy"
     path = CURRENT_DIR / path_location
-    command = [mypy_path, path.resolve().as_posix()]
+    with TemporaryDirectory() as cache_dir:
+        command = [
+            mypy_path,
+            "--cache-dir",
+            cache_dir,
+            path.resolve().as_posix(),
+        ]
 
-    process = subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-    )
+        process = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+        )
     output = process.stdout + process.stderr
     return output
 
@@ -113,6 +120,12 @@ def test_check_app_default(
                     raise
             else:
                 break
+
+
+def test_route_handler_registration() -> None:
+    output = run_check("samples/route_handler_registration.py")
+
+    assert "unused-coroutine" not in output
 
 
 def _text_from_path(


### PR DESCRIPTION
Fixes #3159.

### Summary
- widen `RouteHandler` from `Coroutine` to `Awaitable` so non-decorator route registration does not trigger mypy's unused coroutine check
- update the internal handler response annotation to match the widened route handler type
- add a typing sample for registering a bound async method through `app.get(...)(handler)`

### Testing
- `python -m pytest tests\typing\test_typing.py -q`
- `python -m pytest tests\test_handler.py -q`
- `python -m ruff check sanic\app.py sanic\models\handler_types.py tests\typing\test_typing.py tests\typing\samples\route_handler_registration.py`
- `python -m ruff format --check sanic\app.py sanic\models\handler_types.py tests\typing\test_typing.py tests\typing\samples\route_handler_registration.py`
- `git diff --check`