### PR TITLE
fix: respect register_sys_signals=False (#2956)

### DIFF
--- a/sanic/server/runners.py
+++ b/sanic/server/runners.py
@@ -162,11 +162,18 @@ def _setup_system_signals(
     register_sys_signals: bool,
     loop: asyncio.AbstractEventLoop,
 ) -> None:  # no cov
-    signal_func(SIGINT, SIG_IGN)
-    signal_func(SIGTERM, SIG_IGN)
     os.environ["SANIC_WORKER_PROCESS"] = "true"
     # Register signals for graceful termination
     if register_sys_signals:
+        # Reset the default Python signal handlers before installing the
+        # asyncio handlers below. Without this, the existing handlers (e.g.
+        # the default SIGINT -> KeyboardInterrupt) may race with the
+        # asyncio loop's add_signal_handler on some platforms. When the
+        # caller opts out via ``register_sys_signals=False`` they are
+        # explicitly taking over signal handling, so leave their handlers
+        # intact (see GH issue #2956).
+        signal_func(SIGINT, SIG_IGN)
+        signal_func(SIGTERM, SIG_IGN)
         if OS_IS_WINDOWS:
             ctrlc_workaround_for_windows(app)
         else:

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -96,6 +96,41 @@ def test_dont_register_system_signals(app):
     assert calledq.get() is False
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signal semantics")
+def test_dont_register_system_signals_preserves_user_handlers(app):
+    """Regression test for GH #2956.
+
+    When ``register_sys_signals=False`` the caller is opting out of Sanic's
+    own signal handling, so any signal handlers they have installed on
+    SIGINT/SIGTERM must not be overwritten with ``SIG_IGN``.
+    """
+    from sanic.server.runners import _setup_system_signals
+
+    # Install user-land handlers that we expect to survive the call.
+    def user_handler(_signum, _frame):  # pragma: no cover - sentinel only
+        pass
+
+    old_int = signal.signal(signal.SIGINT, user_handler)
+    old_term = signal.signal(signal.SIGTERM, user_handler)
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            _setup_system_signals(
+                app,
+                run_multiple=False,
+                register_sys_signals=False,
+                loop=loop,
+            )
+            # Handlers must still point at the user's callable, not SIG_IGN.
+            assert signal.getsignal(signal.SIGINT) is user_handler
+            assert signal.getsignal(signal.SIGTERM) is user_handler
+        finally:
+            loop.close()
+    finally:
+        signal.signal(signal.SIGINT, old_int)
+        signal.signal(signal.SIGTERM, old_term)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="windows cannot SIGINT processes")
 def test_windows_workaround():
     """Test Windows workaround (on any other OS)"""


### PR DESCRIPTION
## Summary

Fixes #2956.

`Sanic.run(..., register_sys_signals=False)` is the documented escape hatch for callers that take over SIGINT/SIGTERM themselves (for instance an orchestrator that wraps Sanic inside a larger process and only wants the orchestrator to react to Ctrl-C). Since 4499d2c4 (#2811, "Cleaner process management"), `_setup_system_signals` unconditionally calls `signal_func(SIGINT, SIG_IGN)` / `signal_func(SIGTERM, SIG_IGN)` at function entry, before checking the `register_sys_signals` flag. The flag still suppresses `loop.add_signal_handler(...)`, but the user's pre-existing Python-level handlers are already gone, replaced with `SIG_IGN`. Net effect: opting out of Sanic's signal handling silently disables the caller's signal handling too.

The fix moves the `SIG_IGN` reset inside the `register_sys_signals` branch. The reset is still useful there as a safety step before installing the asyncio handlers (and the existing test `test_register_system_signals` still passes), but it no longer runs on the opt-out path.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# From the repo root (Linux/macOS, on POSIX SIGINT/SIGTERM semantics)
cd /tmp && rm -rf repro-2956 && mkdir repro-2956 && cd repro-2956
python3 -m venv .venv && source .venv/bin/activate
pip install -q "sanic @ git+https://github.com/sanic-org/sanic.git@main"   # BEFORE
# pip install -q "sanic @ git+https://github.com/jbbqqf/sanic.git@fix/2956-respect-register-sys-signals"  # AFTER

cat > repro.py <<'PY'
import asyncio, signal
from sanic.server.runners import _setup_system_signals

calls = []
def my_handler(signum, frame):  # the caller's handler
    calls.append(signum)

signal.signal(signal.SIGINT, my_handler)
signal.signal(signal.SIGTERM, my_handler)

class _StubApp:
    debug = False
    state = type("S", (), {"is_stopping": False, "is_running": False})()
    def stop(self, *a, **kw): pass

loop = asyncio.new_event_loop()
_setup_system_signals(_StubApp(), run_multiple=False,
                     register_sys_signals=False, loop=loop)

print("SIGINT  ->", signal.getsignal(signal.SIGINT))
print("SIGTERM ->", signal.getsignal(signal.SIGTERM))
# Expected BEFORE: Handlers.SIG_IGN (bug — caller's my_handler clobbered)
# Expected AFTER : <function my_handler> (caller's handler preserved)
PY
python repro.py
```

## What I ran locally

```
$ pytest tests/test_signal_handlers.py -v
...
tests/test_signal_handlers.py::test_register_system_signals PASSED
tests/test_signal_handlers.py::test_no_register_system_signals_fails PASSED
tests/test_signal_handlers.py::test_dont_register_system_signals PASSED
tests/test_signal_handlers.py::test_dont_register_system_signals_preserves_user_handlers PASSED
tests/test_signal_handlers.py::test_windows_workaround PASSED
tests/test_signal_handlers.py::test_signals_with_invalid_invocation PASSED
tests/test_signal_handlers.py::test_signal_server_lifecycle_exception PASSED
======================== 7 passed, 7 warnings in 0.99s ========================

$ pytest tests/test_signal_handlers.py tests/test_signals.py tests/test_app.py tests/worker/ -q
1 failed, 254 passed, 28 warnings in 7.84s
# The single failure is tests/worker/test_socket.py::test_configure_socket
# (AF_UNIX path-too-long in this sandbox) and reproduces identically on
# unmodified main — not caused by this change.
```

The new test `test_dont_register_system_signals_preserves_user_handlers`
is the regression. It calls `_setup_system_signals(..., register_sys_signals=False)`
directly so the assertion is deterministic and doesn't depend on whether
`app.run` is spun up. Run it against `origin/main` to see it fail with
`SIG_IGN is not <user_handler>`; run it on this branch to see it pass.

## Edge cases

| Case | Behavior before | Behavior after |
|---|---|---|
| `register_sys_signals=True` (default), no prior user handler | Sanic installs asyncio handlers via `loop.add_signal_handler`; default Python handler reset to `SIG_IGN` first | Unchanged — same path |
| `register_sys_signals=True`, user pre-installed a handler | User handler replaced with `SIG_IGN`, then asyncio handler installed | Unchanged — same path (Sanic's documented behavior when it owns signals) |
| `register_sys_signals=False`, no prior user handler | SIGINT/SIGTERM forced to `SIG_IGN` (silent regression vs. pre-#2811) | Default handlers preserved (Python's `default_int_handler` for SIGINT, default for SIGTERM) |
| `register_sys_signals=False`, user pre-installed a handler | **User handler clobbered → #2956 bug** | User handler preserved |
| Windows path (`OS_IS_WINDOWS`) with `register_sys_signals=True` | Calls `ctrlc_workaround_for_windows` | Unchanged |
| `run_multiple=True` workers | Still set `SANIC_WORKER_PROCESS=true`; signals reset only when worker registers signals | Same; the env var assignment was moved out of the SIG_IGN block but still runs |

---

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against sanic's source (`sanic/server/runners.py` at 785d77f8, the v25.12 release commit). The reproducer block above is the one I used during development; reviewers can paste it verbatim.*
