### PR TITLE
Exception tracebacks: TraceRite 2.5 update

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,12 +1,6 @@
 import tracerite
 
-try:
-    tracerite.load()
-except Exception as exc:
-    raise RuntimeError(
-        "Failed to initialize tracerite. Please verify that tracerite is "
-        "correctly installed and compatible with this environment."
-    ) from exc
+tracerite.load()
 
 from sanic.cli.app import SanicCLI
 from sanic.compat import OS_IS_WINDOWS, enable_windows_color_support

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -37,6 +37,8 @@ from typing import (
     cast,
 )
 
+import tracerite
+
 from sanic.application.ext import setup_ext
 from sanic.application.logo import get_logo
 from sanic.application.motd import MOTD
@@ -991,6 +993,7 @@ class StartupMixin(metaclass=SanicMeta):
                 Sanic.serve()
             ```
         """
+        tracerite.load()
         cls._set_startup_method()
         os.environ["SANIC_MOTD_OUTPUT"] = "true"
         apps = list(cls._app_registry.values())

--- a/sanic/pages/error.py
+++ b/sanic/pages/error.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from html5tagger import E, HTML
+from html5tagger import HTML, E
 from tracerite import html_traceback, inspector
 from tracerite.html import javascript, style
 

--- a/sanic/pages/error.py
+++ b/sanic/pages/error.py
@@ -1,11 +1,12 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, ClassVar
 
-import tracerite.html
-
-from html5tagger import E
+from html5tagger import Document, E, HTML, Template
 from tracerite import html_traceback, inspector
+from tracerite.html import PAGE_STYLE, Header, javascript, style
 
+from sanic import __version__ as VERSION
+from sanic.application.logo import SVG_LOGO_SIMPLE
 from sanic.request import Request
 
 from .base import BasePage
@@ -25,7 +26,7 @@ for the inconvenience and appreciate your patience.\
 class ErrorPage(BasePage):
     """Page for displaying an error."""
 
-    STYLE_APPEND = tracerite.html.style
+    _template: ClassVar[Template | None] = None
 
     def __init__(
         self,
@@ -49,64 +50,141 @@ class ErrorPage(BasePage):
         self.exc = exc
         self.details_open = not getattr(exc, "quiet", False)
 
-    def _head(self) -> None:
-        self.doc._script(tracerite.html.javascript)
-        super()._head()
+    def _header(self) -> HTML:
+        """Sanic site-wide header with the application heading."""
+        with E.header as header:
+            header.div(self.HEADING or self.TITLE)
+        return HTML(header)
+
+    def _footer(self) -> HTML:
+        """Sanic footer with logo, version, and help links."""
+        with E.footer as footer:
+            footer.div("powered by")
+            with footer.div:
+                footer.a(
+                    HTML(SVG_LOGO_SIMPLE),
+                    href="https://sanic.dev",
+                    target="_blank",
+                    referrerpolicy="no-referrer",
+                )
+            if self.debug:
+                footer.div(f"Version {VERSION}")
+                with footer.div:
+                    for idx, (title, href) in enumerate(
+                        (
+                            ("Docs", "https://sanic.dev"),
+                            ("Help", "https://sanic.dev/en/help.html"),
+                            ("GitHub", "https://github.com/sanic-org/sanic"),
+                        )
+                    ):
+                        if idx > 0:
+                            footer(" | ")
+                        footer.a(
+                            title,
+                            href=href,
+                            target="_blank",
+                            referrerpolicy="no-referrer",
+                        )
+                footer.div("DEBUG mode")
+        return HTML(footer)
 
     def _body(self) -> None:
+        """Not used; ErrorPage renders via the TraceRite Page template."""
+
+    def _content(self) -> HTML:
+        """Main content: context, end-user message, or debug details."""
         debug = self.request.app.debug
         route_name = self.request.name or "[route not found]"
-        with self.doc.main:
-            self.doc.h1(f"⚠️ {self.title}").p(self.text)
-            # Show context details if available on the exception
-            context = getattr(self.exc, "context", None)
-            if context:
+        content = E.div()
+
+        # Show context details if available on the exception
+        context = getattr(self.exc, "context", None)
+        if context:
+            self._key_value_table(
+                content, "Issue context", "exception-context", context
+            )
+
+        if not debug:
+            with content.div(id="enduser"):
+                content.p(ENDUSER_TEXT).p.a("Front Page", href="/")
+            return HTML(content)
+
+        # Show additional details in debug mode,
+        # open by default for 500 errors
+        with content.details(open=self.details_open, class_="smalltext"):
+            # Show extra details if available on the exception
+            extra = getattr(self.exc, "extra", None)
+            if extra:
                 self._key_value_table(
-                    "Issue context", "exception-context", context
+                    content, "Issue extra data", "exception-extra", extra
                 )
 
-            if not debug:
-                with self.doc.div(id="enduser"):
-                    self.doc.p(ENDUSER_TEXT).p.a("Front Page", href="/")
-                return
-            # Show additional details in debug mode,
-            # open by default for 500 errors
-            with self.doc.details(open=self.details_open, class_="smalltext"):
-                # Show extra details if available on the exception
-                extra = getattr(self.exc, "extra", None)
-                if extra:
-                    self._key_value_table(
-                        "Issue extra data", "exception-extra", extra
+            content.summary(
+                "Details for developers (Sanic debug mode only)"
+            )
+            if self.exc:
+                with content.div(class_="exception-wrapper"):
+                    content.h2(f"Exception in {route_name}:")
+                    content(
+                        html_traceback(self.exc, include_js_css=False)
                     )
 
-                self.doc.summary(
-                    "Details for developers (Sanic debug mode only)"
-                )
-                if self.exc:
-                    with self.doc.div(class_="exception-wrapper"):
-                        self.doc.h2(f"Exception in {route_name}:")
-                        self.doc(
-                            html_traceback(self.exc, include_js_css=False)
-                        )
+            self._key_value_table(
+                content,
+                f"{self.request.method} {self.request.path}",
+                "request-headers",
+                self.request.headers,
+            )
 
-                self._key_value_table(
-                    f"{self.request.method} {self.request.path}",
-                    "request-headers",
-                    self.request.headers,
-                )
+        return HTML(content)
 
     def _key_value_table(
-        self, title: str, table_id: str, data: Mapping[str, Any]
+        self,
+        doc: Any,
+        title: str,
+        table_id: str,
+        data: Mapping[str, Any],
     ) -> None:
-        with self.doc.div(class_="key-value-display"):
-            self.doc.h2(title)
-            with self.doc.dl(id=table_id, class_="key-value-table smalltext"):
+        with doc.div(class_="key-value-display"):
+            doc.h2(title)
+            with doc.dl(id=table_id, class_="key-value-table smalltext"):
                 for key, value in data.items():
                     # Reading values may cause a new exception, so suppress it
                     try:
                         value = str(value)
                     except Exception:
                         value = E.em("Unable to display value")
-                    self.doc.dt.span(key, class_="nobr key").span(": ").dd(
+                    doc.dt.span(key, class_="nobr key").span(": ").dd(
                         value
                     )
+
+    def render(self) -> str:
+        """Render the error page using TraceRite's Page template.
+
+        Sanic-specific styling and extra information (context, request
+        headers, footer links, etc.) are injected into the template slots.
+        """
+        cls = self.__class__
+        if cls._template is None:
+            cls._template = Template(
+                Document(E.Title, lang="en", id="sanic")
+                .style(style)
+                .style(PAGE_STYLE)
+                .style(HTML(self.CSS))
+                .script(javascript)
+                .Header
+                .main(E.Heading.Content)
+                .Footer
+            )
+
+        return str(
+            self._template(
+                Title=self.TITLE,
+                Header=self._header(),
+                Heading=Header(
+                    Heading=E("⚠️ ")(self.title), Ingress=self.text
+                ),
+                Content=self._content(),
+                Footer=self._footer(),
+            )
+        )

--- a/sanic/pages/error.py
+++ b/sanic/pages/error.py
@@ -1,15 +1,19 @@
 from collections.abc import Mapping
-from typing import Any, ClassVar
+from pathlib import Path
+from typing import Any
 
-from html5tagger import Document, E, HTML, Template
+from html5tagger import E, HTML
 from tracerite import html_traceback, inspector
-from tracerite.html import PAGE_STYLE, Header, javascript, style
+from tracerite.html import javascript, style
 
-from sanic import __version__ as VERSION
-from sanic.application.logo import SVG_LOGO_SIMPLE
 from sanic.request import Request
 
 from .base import BasePage
+
+
+TRACERITE_OVERRIDE_CSS = (
+    Path(__file__).parent / "styles" / "ErrorPageTraceRite.css"
+).read_text(encoding="UTF-8")
 
 
 # Avoid showing the request in the traceback variable inspectors
@@ -25,8 +29,6 @@ for the inconvenience and appreciate your patience.\
 
 class ErrorPage(BasePage):
     """Page for displaying an error."""
-
-    _template: ClassVar[Template | None] = None
 
     def __init__(
         self,
@@ -50,141 +52,68 @@ class ErrorPage(BasePage):
         self.exc = exc
         self.details_open = not getattr(exc, "quiet", False)
 
-    def _header(self) -> HTML:
-        """Sanic site-wide header with the application heading."""
-        with E.header as header:
-            header.div(self.HEADING or self.TITLE)
-        return HTML(header)
-
-    def _footer(self) -> HTML:
-        """Sanic footer with logo, version, and help links."""
-        with E.footer as footer:
-            footer.div("powered by")
-            with footer.div:
-                footer.a(
-                    HTML(SVG_LOGO_SIMPLE),
-                    href="https://sanic.dev",
-                    target="_blank",
-                    referrerpolicy="no-referrer",
-                )
-            if self.debug:
-                footer.div(f"Version {VERSION}")
-                with footer.div:
-                    for idx, (title, href) in enumerate(
-                        (
-                            ("Docs", "https://sanic.dev"),
-                            ("Help", "https://sanic.dev/en/help.html"),
-                            ("GitHub", "https://github.com/sanic-org/sanic"),
-                        )
-                    ):
-                        if idx > 0:
-                            footer(" | ")
-                        footer.a(
-                            title,
-                            href=href,
-                            target="_blank",
-                            referrerpolicy="no-referrer",
-                        )
-                footer.div("DEBUG mode")
-        return HTML(footer)
+    def _head(self) -> None:
+        # Only include TraceRite assets when the traceback will be shown
+        if self.request.app.debug:
+            self.doc.style(HTML(style))
+            self.doc.style(HTML(TRACERITE_OVERRIDE_CSS))
+            self.doc._script(javascript)
+        super()._head()
 
     def _body(self) -> None:
-        """Not used; ErrorPage renders via the TraceRite Page template."""
-
-    def _content(self) -> HTML:
-        """Main content: context, end-user message, or debug details."""
         debug = self.request.app.debug
         route_name = self.request.name or "[route not found]"
-        content = E.div()
-
-        # Show context details if available on the exception
-        context = getattr(self.exc, "context", None)
-        if context:
-            self._key_value_table(
-                content, "Issue context", "exception-context", context
-            )
-
-        if not debug:
-            with content.div(id="enduser"):
-                content.p(ENDUSER_TEXT).p.a("Front Page", href="/")
-            return HTML(content)
-
-        # Show additional details in debug mode,
-        # open by default for 500 errors
-        with content.details(open=self.details_open, class_="smalltext"):
-            # Show extra details if available on the exception
-            extra = getattr(self.exc, "extra", None)
-            if extra:
+        with self.doc.main:
+            self.doc.h1(f"⚠️ {self.title}").p(self.text)
+            # Show context details if available on the exception
+            context = getattr(self.exc, "context", None)
+            if context:
                 self._key_value_table(
-                    content, "Issue extra data", "exception-extra", extra
+                    "Issue context", "exception-context", context
                 )
 
-            content.summary(
-                "Details for developers (Sanic debug mode only)"
-            )
-            if self.exc:
-                with content.div(class_="exception-wrapper"):
-                    content.h2(f"Exception in {route_name}:")
-                    content(
-                        html_traceback(self.exc, include_js_css=False)
+            if not debug:
+                with self.doc.div(id="enduser"):
+                    self.doc.p(ENDUSER_TEXT).p.a("Front Page", href="/")
+                return
+            # Show additional details in debug mode,
+            # open by default for 500 errors
+            with self.doc.details(open=self.details_open, class_="smalltext"):
+                # Show extra details if available on the exception
+                extra = getattr(self.exc, "extra", None)
+                if extra:
+                    self._key_value_table(
+                        "Issue extra data", "exception-extra", extra
                     )
 
-            self._key_value_table(
-                content,
-                f"{self.request.method} {self.request.path}",
-                "request-headers",
-                self.request.headers,
-            )
+                self.doc.summary(
+                    "Details for developers (Sanic debug mode only)"
+                )
+                if self.exc:
+                    with self.doc.div(class_="exception-wrapper"):
+                        self.doc.h2(f"Exception in {route_name}:")
+                        self.doc(
+                            html_traceback(self.exc, include_js_css=False)
+                        )
 
-        return HTML(content)
+                self._key_value_table(
+                    f"{self.request.method} {self.request.path}",
+                    "request-headers",
+                    self.request.headers,
+                )
 
     def _key_value_table(
-        self,
-        doc: Any,
-        title: str,
-        table_id: str,
-        data: Mapping[str, Any],
+        self, title: str, table_id: str, data: Mapping[str, Any]
     ) -> None:
-        with doc.div(class_="key-value-display"):
-            doc.h2(title)
-            with doc.dl(id=table_id, class_="key-value-table smalltext"):
+        with self.doc.div(class_="key-value-display"):
+            self.doc.h2(title)
+            with self.doc.dl(id=table_id, class_="key-value-table smalltext"):
                 for key, value in data.items():
                     # Reading values may cause a new exception, so suppress it
                     try:
                         value = str(value)
                     except Exception:
                         value = E.em("Unable to display value")
-                    doc.dt.span(key, class_="nobr key").span(": ").dd(
+                    self.doc.dt.span(key, class_="nobr key").span(": ").dd(
                         value
                     )
-
-    def render(self) -> str:
-        """Render the error page using TraceRite's Page template.
-
-        Sanic-specific styling and extra information (context, request
-        headers, footer links, etc.) are injected into the template slots.
-        """
-        cls = self.__class__
-        if cls._template is None:
-            cls._template = Template(
-                Document(E.Title, lang="en", id="sanic")
-                .style(style)
-                .style(PAGE_STYLE)
-                .style(HTML(self.CSS))
-                .script(javascript)
-                .Header
-                .main(E.Heading.Content)
-                .Footer
-            )
-
-        return str(
-            self._template(
-                Title=self.TITLE,
-                Header=self._header(),
-                Heading=Header(
-                    Heading=E("⚠️ ")(self.title), Ingress=self.text
-                ),
-                Content=self._content(),
-                Footer=self._footer(),
-            )
-        )

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -133,5 +133,4 @@ span.icon {
         Consolas,
         Lucida Console,
         monospace;
-    font-size: 0.8rem;
 }

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -15,12 +15,6 @@
     --sanic-header-text: #fff;
     --sanic-highlight-background: var(--sanic-yellow);
     --sanic-highlight-text: var(--sanic-text);
-    --sanic-tab-background: #f7f4f6;
-    --sanic-tab-shadow: #f7f6f6;
-    --sanic-tab-text: #222021;
-    --sanic-tracerite-var: var(--sanic-text);
-    --sanic-tracerite-val: #ff0d68;
-    --sanic-tracerite-type: #6d6a6b;
 }
 
 
@@ -33,9 +27,6 @@
         --sanic-header-background: #030203;
         --sanic-header-border: #000;
         --sanic-highlight-text: var(--sanic-background);
-        --sanic-tab-background: #292728;
-        --sanic-tab-shadow: #0f0d0e;
-        --sanic-tab-text: #aea7ab;
     }
 }
 

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -3,11 +3,10 @@
     max-width: 30em;
     margin: 5em auto 5em auto;
     text-align: justify;
-    /*text-justify: both;*/
 }
 
 #enduser a {
-    color: var(--sanic-blue);
+    color: var(--sanic-link);
 }
 
 #enduser p:last-child {
@@ -20,48 +19,24 @@ summary {
     cursor: pointer;
 }
 
-.tracerite {
-    --tracerite-var: var(--sanic-tracerite-var);
-    --tracerite-val: var(--sanic-tracerite-val);
-    --tracerite-type: var(--sanic-tracerite-type);
+/* TraceRite theme overrides */
+#sanic .tracerite {
+    --tracerite-var: var(--sanic-text);
+    --tracerite-val: var(--sanic);
+    --tracerite-type: #6d6a6b;
     --tracerite-exception: var(--sanic);
     --tracerite-highlight: var(--sanic-yellow);
-    --tracerite-tab: var(--sanic-tab-background);
-    --tracerite-tab-text: var(--sanic-tab-text);
+    --tracerite-highlight-text: var(--sanic-text);
+    --tracerite-caret: var(--sanic);
+    --tracerite-function: var(--sanic-link);
+    --tracerite-location: var(--sanic-text-lighter);
+    --tracerite-lineno: var(--sanic-text-lighter);
 }
 
-.tracerite>h3 {
-    margin: 0.5rem 0 !important;
-}
-
-#sanic .tracerite .traceback-labels button {
-    font-size: 0.8rem;
-    line-height: 120%;
-    background: var(--tracerite-tab);
-    color: var(--tracerite-tab-text);
-    transition: 0.3s;
-    cursor: pointer;
-}
-
-.tracerite .traceback-labels {
-    padding-top: 5px;
-}
-
-.tracerite .traceback-labels button:hover {
-    filter: contrast(150%) brightness(120%) drop-shadow(0 -0 2px var(--sanic-tab-shadow));
-}
-
-#sanic .tracerite .tracerite-tooltip::before {
-    bottom: 1.75em;
-}
-
-#sanic .tracerite .traceback-details mark span {
-    background: var(--sanic-highlight-background);
-    color: var(--sanic-highlight-text);
-}
-
-header {
-    background: var(--sanic-header-background);
+@media (prefers-color-scheme: dark) {
+    #sanic .tracerite {
+        --tracerite-type: #a8a3a5;
+    }
 }
 
 h2 {

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -19,26 +19,6 @@ summary {
     cursor: pointer;
 }
 
-/* TraceRite theme overrides */
-#sanic .tracerite {
-    --tracerite-var: var(--sanic-text);
-    --tracerite-val: var(--sanic);
-    --tracerite-type: #6d6a6b;
-    --tracerite-exception: var(--sanic);
-    --tracerite-highlight: var(--sanic-yellow);
-    --tracerite-highlight-text: var(--sanic-text);
-    --tracerite-caret: var(--sanic);
-    --tracerite-function: var(--sanic-link);
-    --tracerite-location: var(--sanic-text-lighter);
-    --tracerite-lineno: var(--sanic-text-lighter);
-}
-
-@media (prefers-color-scheme: dark) {
-    #sanic .tracerite {
-        --tracerite-type: #a8a3a5;
-    }
-}
-
 h2 {
     font-size: 1.3rem;
     color: var(--sanic-text);

--- a/sanic/pages/styles/ErrorPageTraceRite.css
+++ b/sanic/pages/styles/ErrorPageTraceRite.css
@@ -5,9 +5,10 @@
     --tracerite-type: #6d6a6b;
     --tracerite-exception: var(--sanic);
     --tracerite-highlight: var(--sanic-yellow);
-    --tracerite-highlight-text: var(--sanic-text);
+    --tracerite-highlight-text: var(--sanic-highlight-text);
+    --tracerite-call-symbol-color: var(--sanic-yellow);
+    --tracerite-call-highlight: var(--sanic-yellow);
     --tracerite-caret: var(--sanic);
-    --tracerite-function: var(--sanic-link);
     --tracerite-location: var(--sanic-text-lighter);
     --tracerite-lineno: var(--sanic-text-lighter);
 }

--- a/sanic/pages/styles/ErrorPageTraceRite.css
+++ b/sanic/pages/styles/ErrorPageTraceRite.css
@@ -1,0 +1,19 @@
+/* TraceRite theme overrides for Sanic (debug-mode error pages only) */
+#sanic .tracerite {
+    --tracerite-var: var(--sanic-text);
+    --tracerite-val: var(--sanic);
+    --tracerite-type: #6d6a6b;
+    --tracerite-exception: var(--sanic);
+    --tracerite-highlight: var(--sanic-yellow);
+    --tracerite-highlight-text: var(--sanic-text);
+    --tracerite-caret: var(--sanic);
+    --tracerite-function: var(--sanic-link);
+    --tracerite-location: var(--sanic-text-lighter);
+    --tracerite-lineno: var(--sanic-text-lighter);
+}
+
+@media (prefers-color-scheme: dark) {
+    #sanic .tracerite {
+        --tracerite-type: #a8a3a5;
+    }
+}

--- a/sanic/worker/serve.py
+++ b/sanic/worker/serve.py
@@ -51,11 +51,10 @@ def worker_serve(
     config: bytes | str | dict[str, Any] | Any | None = None,
     passthru: dict[str, Any] | None = None,
 ):
-    tracerite.load()
-
     try:
         from sanic import Sanic
 
+        tracerite.load()
         if app_loader:
             app = app_loader.load()
         else:

--- a/sanic/worker/serve.py
+++ b/sanic/worker/serve.py
@@ -10,6 +10,8 @@ from multiprocessing.connection import Connection
 from ssl import SSLContext
 from typing import Any
 
+import tracerite
+
 from sanic.application.constants import ServerStage
 from sanic.application.state import ApplicationServerInfo
 from sanic.http.constants import HTTP
@@ -49,6 +51,8 @@ def worker_serve(
     config: bytes | str | dict[str, Any] | Any | None = None,
     passthru: dict[str, Any] | None = None,
 ):
+    tracerite.load()
+
     try:
         from sanic import Sanic
 

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,8 @@ requirements = [
     "aiofiles>=0.6.0",
     "websockets>=10.0",
     "multidict>=5.0,<7.0",
-    "html5tagger>=1.2.1",
-    "tracerite>=2.2.0",
+    "html5tagger>=2.0.0",
+    "tracerite>=2.5.0",
     "typing-extensions>=4.4.0",
     "setuptools>=70.1.0",
 ]

--- a/tests/test_exceptions_handler.py
+++ b/tests/test_exceptions_handler.py
@@ -150,10 +150,12 @@ def test_chained_exception_handler(exception_handler_app: Sanic):
     assert "ValueError" in html
     assert "GET /6" in html
 
-    # Both exceptions should be present in the traceback headers
+    # The raised exception should be present in the traceback headers.
+    # TraceRite 2.5+ indicates the chained cause with "from previous" rather
+    # than repeating the cause exception type when it has no distinct frames.
     header_texts = [h.text for h in soup.select("h2, h3")]
     assert any("ZeroDivisionError" in text for text in header_texts)
-    assert any("ValueError" in text for text in header_texts)
+    assert any("from previous" in text for text in header_texts)
 
 
 def test_exception_handler_lookup(exception_handler_app: Sanic):


### PR DESCRIPTION
Updated TraceRite Sanic integration for the latest version. Removes styling for old tabbed layout that was removed in 2.0, and increases font size to default 16px because there is more screen space in the new layout. Adds TraceRite loading on two new entry points (previously only Sanic CLI), to catch other entry modes and multiprocessing spawn previously missed.
