### PR TITLE
fix: correct typos in docs

### DIFF
--- a/guide/content/en/guide/best-practices/exceptions.md
+++ b/guide/content/en/guide/best-practices/exceptions.md
@@ -126,7 +126,7 @@ All of these properties can be passed to the exception when it is created, but t
 
     ### `headers`
 
-    Using `SanicException` as a tool for creating responses is super powerful. This is in part because not only can you control the `status_code`, but you can also control reponse headers directly from the exception.
+    Using `SanicException` as a tool for creating responses is super powerful. This is in part because not only can you control the `status_code`, but you can also control response headers directly from the exception.
 
 .. column::
 

--- a/guide/content/en/guide/running/inspector.md
+++ b/guide/content/en/guide/running/inspector.md
@@ -66,7 +66,7 @@ Once the inspector is running, you will have access to it via the CLI or by dire
 
 .. note:: 
 
-    Remember, the Inspector is not running on your Sanic application. It is a seperate process, with a seperate application, and exposed on a seperate socket.
+    Remember, the Inspector is not running on your Sanic application. It is a separate process, with a separate application, and exposed on a separate socket.
 
 
 

--- a/guide/content/en/release-notes/2022/v22.9.md
+++ b/guide/content/en/release-notes/2022/v22.9.md
@@ -34,7 +34,7 @@ This **does NOT apply** to Sanic in ASGI mode
     - Possible use cases:
         - Health monitor, see [Sanic Extensions]()
         - Logging queue, see [Sanic Extensions]()
-        - Background worker queue in a seperate process
+        - Background worker queue in a separate process
         - Running another application, like a bot
 - There is a new listener called: `main_process_ready`. It really should only be used for adding arbitrary processes to Sanic.
 - Passing shared objects between workers.


### PR DESCRIPTION
Fixes: seperate → separate, reponse → response